### PR TITLE
FIX: EXIT_CODE was being set in a subshell

### DIFF
--- a/travis/tc3_pragmalint.sh
+++ b/travis/tc3_pragmalint.sh
@@ -8,44 +8,42 @@ pip install pytmc
 
 EXIT_CODE=0
 
-find . -name '*.tsproj' -print0 | 
-    while IFS= read -r -d '' tsproj; do 
-        echo "Pragma lint results"
-        echo "-------------------"
-        pytmc pragmalint --verbose "$tsproj"
-        if [ $? -ne 0 ]; then
-            EXIT_CODE=1
-        fi
+while IFS= read -r -d '' tsproj; do 
+    echo "Pragma lint results"
+    echo "-------------------"
+    pytmc pragmalint --verbose "$tsproj"
+    if [ $? -ne 0 ]; then
+        EXIT_CODE=1
+    fi
+    echo ""
+done < <(find . -name '*.tsproj' -print0)
+
+while IFS= read -r -d '' tmc; do
+    db_errors=$(( ( pytmc db --allow-errors "$tmc") 1>/dev/null) 2>&1)
+
+    echo "$(basename $tmc)"
+    echo "=================="
+    echo ""
+
+    if [ ! -z "$db_errors" ]; then
+        EXIT_CODE=2
+        echo "Errors"
+        echo "------"
+        echo "$db_errors"
         echo ""
-    done
+    fi
 
-find . -name '*.tmc' -print0 |
-    while IFS= read -r -d '' tmc; do
-        db_errors=$(( ( pytmc db --allow-errors "$tmc") 1>/dev/null) 2>&1)
+    echo "Records"
+    echo "-------"
+    (pytmc db --allow-errors "$tmc" 2> /dev/null) | grep "^record" | sed -e 's/^record(\(.*\),\(.*\)).*$/\2 (\1)/' | sort
+    echo ""
 
-        echo "$(basename $tmc)"
-        echo "=================="
-        echo ""
+    echo "EPICS database"
+    echo "--------------"
+    pytmc db --allow-errors "$tmc" 2> /dev/null
+done < <(find . -name '*.tmc' -print0)
 
-        if [ ! -z "$db_errors" ]; then
-            echo "Errors"
-            echo "------"
-            echo "$db_errors"
-            echo ""
-
-            if [ $? -ne 0 ]; then
-                EXIT_CODE=2
-            fi
-        fi
-
-        echo "Records"
-        echo "-------"
-        (pytmc db --allow-errors "$tmc" 2> /dev/null) | grep "^record" | sed -e 's/^record(\(.*\),\(.*\)).*$/\2 (\1)/' | sort
-        echo ""
-
-        echo "EPICS database"
-        echo "--------------"
-        pytmc db --allow-errors "$tmc" 2> /dev/null
-    done
-
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "tc3_pragmalint.sh is exiting with code: $EXIT_CODE"
+fi
 exit $EXIT_CODE


### PR DESCRIPTION
Using process substitution to instead run it in the same shell such that the modified value will be used. _bash_ 👀 

Closes #7 