### PR TITLE
ENH: add twincat 3 style checks from lcls-plc-lfe-motion

### DIFF
--- a/travis/init.sh
+++ b/travis/init.sh
@@ -27,5 +27,14 @@ if [[ ! -z "$TWINCAT_BUILD_DOCS" ]]; then
     exit
 fi
 
+if [[ ! -z "$TWINCAT_STYLE" ]]; then
+    pushd tc3_style
+    bash check.sh; exit_code=$?
+    # Attempt parsing the code, but use the return code from the simple check
+    # script
+    bash parse.sh
+    exit $exit_code
+fi
+
 popd
 popd

--- a/travis/settings.sh
+++ b/travis/settings.sh
@@ -1,3 +1,14 @@
+_header() {
+    echo ""
+    echo "-------------------------------------------------------"
+    for line in "$@"
+    do
+        echo "$line";
+    done
+    echo "-------------------------------------------------------"
+}
+
+
 export TWINCAT_PROJECT_ROOT=${TWINCAT_PROJECT_ROOT:-$TRAVIS_BUILD_DIR}
 
 if [ -z "$CI_HELPER_PATH" ]; then

--- a/travis/tc3_style/check.sh
+++ b/travis/tc3_style/check.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
+
+source $CI_HELPER_PATH/travis/settings.sh
+
 exit_code=0
+
+_header "Checking that source code files do not contain tabs..."
 
 tab_lines=$(./files.sh | xargs awk '/\t/' | wc -l)
 if [ "${tab_lines}" -ne 0 ]; then
@@ -7,16 +12,22 @@ if [ "${tab_lines}" -ne 0 ]; then
   exit_code=1
 fi
 
+_header "Checking for lines with trailing whitespace..."
+
 bad_whitespace_lines=$(./files.sh | xargs egrep $' +$| +\r$' | wc -l)
 if [ "${bad_whitespace_lines}" -ne 0 ]; then
   echo "Found ${bad_whitespace_lines} lines with trailing whitespace"
   exit_code=2
 fi
 
+_header "Checking for TwinCAT misconfiguration (Line IDs)..."
+
 lineid_lines=$(./files.sh | xargs grep 'LineId' | wc -l)
 if [ "${lineid_lines}" -ne 0 ]; then
   echo "Found ${lineid_lines} lines with same-file debug line ids (fix your twincat config)"
   exit_code=3
 fi
+
+_header "Style check exiting with code ${exit_code}"
 
 exit $exit_code

--- a/travis/tc3_style/check.sh
+++ b/travis/tc3_style/check.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+exit_code=0
+
+tab_lines=$(./files.sh | xargs awk '/\t/' | wc -l)
+if [ "${tab_lines}" -ne 0 ]; then
+  echo "Found ${tab_lines} lines with tabs"
+  exit_code=1
+fi
+
+bad_whitespace_lines=$(./files.sh | xargs egrep " +$" | wc -l)
+if [ "${bad_whitespace_lines}" -ne 0 ]; then
+  echo "Found ${bad_whitespace_lines} lines with trailing whitespace"
+  exit_code=2
+fi
+
+lineid_lines=$(./files.sh | xargs grep 'LineId' | wc -l)
+if [ "${lineid_lines}" -ne 0 ]; then
+  echo "Found ${lineid_lines} lines with same-file debug line ids (fix your twincat config)"
+  exit_code=3
+fi
+
+exit $exit_code

--- a/travis/tc3_style/check.sh
+++ b/travis/tc3_style/check.sh
@@ -7,7 +7,7 @@ if [ "${tab_lines}" -ne 0 ]; then
   exit_code=1
 fi
 
-bad_whitespace_lines=$(./files.sh | xargs egrep $' +$| +/r$' | wc -l)
+bad_whitespace_lines=$(./files.sh | xargs egrep $' +$| +\r$' | wc -l)
 if [ "${bad_whitespace_lines}" -ne 0 ]; then
   echo "Found ${bad_whitespace_lines} lines with trailing whitespace"
   exit_code=2

--- a/travis/tc3_style/check.sh
+++ b/travis/tc3_style/check.sh
@@ -7,7 +7,7 @@ if [ "${tab_lines}" -ne 0 ]; then
   exit_code=1
 fi
 
-bad_whitespace_lines=$(./files.sh | xargs egrep " +$" | wc -l)
+bad_whitespace_lines=$(./files.sh | xargs egrep $' +$| +/r$' | wc -l)
 if [ "${bad_whitespace_lines}" -ne 0 ]; then
   echo "Found ${bad_whitespace_lines} lines with trailing whitespace"
   exit_code=2

--- a/travis/tc3_style/files.sh
+++ b/travis/tc3_style/files.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-source ../settings.sh
+source $CI_HELPER_PATH/travis/settings.sh
 
 find $TWINCAT_PROJECT_ROOT -regextype posix-extended -regex '.*\.(TcPOU|TcDUT|TcGVL)$'

--- a/travis/tc3_style/files.sh
+++ b/travis/tc3_style/files.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source ../settings.sh
+
+find $TWINCAT_PROJECT_ROOT -regextype posix-extended -regex '.*\.(TcPOU|TcDUT|TcGVL)$'

--- a/travis/tc3_style/fix.sh
+++ b/travis/tc3_style/fix.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./files.sh | xargs sed -i -e 's/\t/    /g'
+./files.sh | xargs sed -i -e 's/\s\+$//g'
+./files.sh | xargs sed -i '/LineId/d'

--- a/travis/tc3_style/parse.sh
+++ b/travis/tc3_style/parse.sh
@@ -2,6 +2,12 @@
 
 source $CI_HELPER_PATH/travis/settings.sh
 
+_header "Note: this is an experimental step and may report" \
+        "errors where there are none. This will _not_ fail the" \
+        "build."
+
 pip install blark
 
 find $TWINCAT_PROJECT_ROOT -name '*.sln' -exec blark parse -vv {} \;
+
+_header "End of experimental parsing"

--- a/travis/tc3_style/parse.sh
+++ b/travis/tc3_style/parse.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source $CI_HELPER_PATH/travis/settings.sh
+
+pip install blark
+
+find $TWINCAT_PROJECT_ROOT -name '*.sln' -exec blark parse -vv {} \;

--- a/travis/tc3_style/parse.sh
+++ b/travis/tc3_style/parse.sh
@@ -6,7 +6,7 @@ _header "Note: this is an experimental step and may report" \
         "errors where there are none. This will _not_ fail the" \
         "build."
 
-pip install blark
+pip install --quiet blark
 
 find $TWINCAT_PROJECT_ROOT -name '*.sln' -exec blark parse -vv {} \;
 


### PR DESCRIPTION
Borrowed from https://github.com/pcdshub/lcls-plc-lfe-motion/blob/master/style/fix_style.sh (with an attempt to keep `git blame` correct...)

Untested as of yet. Intention is to have style checks be required to satisfy, but blark parsing just a warning until it is improved.

The check for a non-zero length string is also dumb here, as we don't do anything with "$TWINCAT_STYLE". This will probably all require a refactor down the road anyway...