### PR TITLE
ENH: TwinCAT Style Check Expanded

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ matrix:
     - name: Documentation building
       python: 3.7
       env: TWINCAT_BUILD_DOCS=1
+    - name: Twincat Style
+      python: 3.7
+      env: TWINCAT_STYLE=1
 
 install:
   # Import the helper scripts

--- a/example_twincat_travis.yml
+++ b/example_twincat_travis.yml
@@ -14,6 +14,8 @@ matrix:
       env: TWINCAT_PRAGMALINT=1
     - name: Build documentation
       env: TWINCAT_BUILD_DOCS=1
+    - name: Twincat Style
+      env: TWINCAT_STYLE=1
 
 install:
   - git clone --depth 1 git://github.com/pcdshub/pcds-ci-helpers.git

--- a/travis/tc3_style/check.sh
+++ b/travis/tc3_style/check.sh
@@ -18,11 +18,11 @@ fi
 
 _header "Checking for lines with trailing whitespace..."
 
-bad_whitespace_lines=$(./files.sh | xargs egrep $' +$| +\r$')
-if [ -n "${bad_whitespace_lines}" ]; then
-  bad_whitespace_count=$(echo "${bad_whitespace_lines}" | wc -l)
-  echo "Found ${bad_whitespace_count} lines with trailing whitespace"
-  echo "${bad_whitespace_lines}"
+whitespace_lines=$(./files.sh | xargs egrep $' +$| +\r$')
+if [ -n "${whitespace_lines}" ]; then
+  whitespace_count=$(echo "${whitespace_lines}" | wc -l)
+  echo "Found ${whitespace_count} lines with trailing whitespace"
+  echo "${whitespace_lines}"
   exit_code=2
 else
   echo "Found no lines with trailing whitespace!"

--- a/travis/tc3_style/check.sh
+++ b/travis/tc3_style/check.sh
@@ -7,8 +7,8 @@ exit_code=0
 _header "Checking that source code files do not contain tabs..."
 
 tab_lines=$(./files.sh | xargs egrep $'\t')
-tab_count=$(echo "${tab_lines}" | wc -l)
-if [ "${tab_count}" -ne 0 ]; then
+if [ -n "${tab_lines}" ]; then
+  tab_count=$(echo "${tab_lines}" | wc -l)
   echo "Found ${tab_count} lines with tabs"
   echo "${tab_lines}"
   exit_code=1
@@ -17,8 +17,8 @@ fi
 _header "Checking for lines with trailing whitespace..."
 
 bad_whitespace_lines=$(./files.sh | xargs egrep $' +$| +\r$')
-bad_whitespace_count=$(echo "${bad_whitespace_lines}" | wc -l)
-if [ "${bad_whitespace_count}" -ne 0 ]; then
+if [ -n "${bad_whitespace_lines}" ]; then
+  bad_whitespace_count=$(echo "${bad_whitespace_lines}" | wc -l)
   echo "Found ${bad_whitespace_count} lines with trailing whitespace"
   echo "${bad_whitespace_lines}"
   exit_code=2
@@ -27,8 +27,8 @@ fi
 _header "Checking for TwinCAT misconfiguration (Line IDs)..."
 
 lineid_lines=$(./files.sh | xargs grep 'LineId')
-lineid_count=$(echo "${lineid_lines}" | wc -l)
-if [ "${lineid_count}" -ne 0 ]; then
+if [ -n "${lineid_lines}" ]; then
+  lineid_count=$(echo "${lineid_lines}" | wc -l)
   echo "Found ${lineid_count} lines with same-file debug line ids (fix your twincat config)"
   echo "${lineid_lines}"
   exit_code=3

--- a/travis/tc3_style/check.sh
+++ b/travis/tc3_style/check.sh
@@ -12,6 +12,8 @@ if [ -n "${tab_lines}" ]; then
   echo "Found ${tab_count} lines with tabs"
   echo "${tab_lines}"
   exit_code=1
+else
+  echo "Found no lines with tabs!"
 fi
 
 _header "Checking for lines with trailing whitespace..."
@@ -22,6 +24,8 @@ if [ -n "${bad_whitespace_lines}" ]; then
   echo "Found ${bad_whitespace_count} lines with trailing whitespace"
   echo "${bad_whitespace_lines}"
   exit_code=2
+else
+  echo "Found no lines with trailing whitespace!"
 fi
 
 _header "Checking for TwinCAT misconfiguration (Line IDs)..."
@@ -32,6 +36,8 @@ if [ -n "${lineid_lines}" ]; then
   echo "Found ${lineid_count} lines with same-file debug line ids (fix your twincat config)"
   echo "${lineid_lines}"
   exit_code=3
+else
+  echo "Found no debug line ids!"
 fi
 
 _header "Style check exiting with code ${exit_code}"

--- a/travis/tc3_style/check.sh
+++ b/travis/tc3_style/check.sh
@@ -6,7 +6,7 @@ exit_code=0
 
 _header "Checking that source code files do not contain tabs..."
 
-tab_lines=$(style/files.sh | xargs egrep $'\t')
+tab_lines=$(./files.sh | xargs egrep $'\t')
 tab_count=$(echo "${tab_lines}" | wc -l)
 if [ "${tab_count}" -ne 0 ]; then
   echo "Found ${tab_count} lines with tabs"
@@ -16,7 +16,7 @@ fi
 
 _header "Checking for lines with trailing whitespace..."
 
-bad_whitespace_lines=$(style/files.sh | xargs egrep $' +$| +\r$')
+bad_whitespace_lines=$(./files.sh | xargs egrep $' +$| +\r$')
 bad_whitespace_count=$(echo "${bad_whitespace_lines}" | wc -l)
 if [ "${bad_whitespace_count}" -ne 0 ]; then
   echo "Found ${bad_whitespace_count} lines with trailing whitespace"

--- a/travis/tc3_style/check.sh
+++ b/travis/tc3_style/check.sh
@@ -4,12 +4,12 @@ source $CI_HELPER_PATH/travis/settings.sh
 
 exit_code=0
 
-_header "Checking that source code files do not contain tabs..."
+_header "Checking that source code files do not contain leading tabs..."
 
-tab_lines=$(./files.sh | xargs egrep $'\t')
+tab_lines=$(./files.sh | xargs egrep $'^\s*\t')
 if [ -n "${tab_lines}" ]; then
   tab_count=$(echo "${tab_lines}" | wc -l)
-  echo "Found ${tab_count} lines with tabs"
+  echo "Found ${tab_count} lines with leading tabs"
   echo "${tab_lines}"
   exit_code=1
 else

--- a/travis/tc3_style/check.sh
+++ b/travis/tc3_style/check.sh
@@ -6,25 +6,31 @@ exit_code=0
 
 _header "Checking that source code files do not contain tabs..."
 
-tab_lines=$(./files.sh | xargs awk '/\t/' | wc -l)
-if [ "${tab_lines}" -ne 0 ]; then
-  echo "Found ${tab_lines} lines with tabs"
+tab_lines=$(style/files.sh | xargs egrep $'\t')
+tab_count=$(echo "${tab_lines}" | wc -l)
+if [ "${tab_count}" -ne 0 ]; then
+  echo "Found ${tab_count} lines with tabs"
+  echo "${tab_lines}"
   exit_code=1
 fi
 
 _header "Checking for lines with trailing whitespace..."
 
-bad_whitespace_lines=$(./files.sh | xargs egrep $' +$| +\r$' | wc -l)
-if [ "${bad_whitespace_lines}" -ne 0 ]; then
-  echo "Found ${bad_whitespace_lines} lines with trailing whitespace"
+bad_whitespace_lines=$(style/files.sh | xargs egrep $' +$| +\r$')
+bad_whitespace_count=$(echo "${bad_whitespace_lines}" | wc -l)
+if [ "${bad_whitespace_count}" -ne 0 ]; then
+  echo "Found ${bad_whitespace_count} lines with trailing whitespace"
+  echo "${bad_whitespace_lines}"
   exit_code=2
 fi
 
 _header "Checking for TwinCAT misconfiguration (Line IDs)..."
 
-lineid_lines=$(./files.sh | xargs grep 'LineId' | wc -l)
-if [ "${lineid_lines}" -ne 0 ]; then
-  echo "Found ${lineid_lines} lines with same-file debug line ids (fix your twincat config)"
+lineid_lines=$(./files.sh | xargs grep 'LineId')
+lineid_count=$(echo "${lineid_lines}" | wc -l)
+if [ "${lineid_count}" -ne 0 ]; then
+  echo "Found ${lineid_count} lines with same-file debug line ids (fix your twincat config)"
+  echo "${lineid_lines}"
   exit_code=3
 fi
 

--- a/travis/tc3_style/check.sh
+++ b/travis/tc3_style/check.sh
@@ -6,7 +6,7 @@ exit_code=0
 
 _header "Checking that source code files do not contain leading tabs..."
 
-tab_lines=$(./files.sh | xargs egrep $'^\s*\t')
+tab_lines=$(./files.sh | xargs grep -En $'^\s*\t')
 if [ -n "${tab_lines}" ]; then
   tab_count=$(echo "${tab_lines}" | wc -l)
   echo "Found ${tab_count} lines with leading tabs"
@@ -18,7 +18,7 @@ fi
 
 _header "Checking for lines with trailing whitespace..."
 
-whitespace_lines=$(./files.sh | xargs egrep $' +$| +\r$')
+whitespace_lines=$(./files.sh | xargs grep -En $' +$| +\r$')
 if [ -n "${whitespace_lines}" ]; then
   whitespace_count=$(echo "${whitespace_lines}" | wc -l)
   echo "Found ${whitespace_count} lines with trailing whitespace"
@@ -30,7 +30,7 @@ fi
 
 _header "Checking for TwinCAT misconfiguration (Line IDs)..."
 
-lineid_lines=$(./files.sh | xargs grep 'LineId')
+lineid_lines=$(./files.sh | xargs grep -n 'LineId')
 if [ -n "${lineid_lines}" ]; then
   lineid_count=$(echo "${lineid_lines}" | wc -l)
   echo "Found ${lineid_count} lines with same-file debug line ids (fix your twincat config)"

--- a/travis/tc3_style/files.sh
+++ b/travis/tc3_style/files.sh
@@ -2,4 +2,9 @@
 
 source $CI_HELPER_PATH/travis/settings.sh
 
-find $TWINCAT_PROJECT_ROOT -regextype posix-extended -regex '.*\.(TcPOU|TcDUT|TcGVL)$'
+all_files=$(find $TWINCAT_PROJECT_ROOT -regextype posix-extended -regex '.*\.(TcPOU|TcDUT|TcGVL)$')
+if [ -z "${TWINCAT_STYLE_EXCLUDE}" ]; then
+  echo "${all_files}"
+else
+  echo "${all_files}" | egrep -v "${TWINCAT_STYLE_EXCLUDE}"
+fi


### PR DESCRIPTION
- Show which files/lines had issues
- Allow user to configure files to exclude from the check via regex
- Add TWINCAT_STYLE to the readme and example
- Add success message for passing checks
- Make only leading tabs fail the tab check, e.g. this is not allowed:
```
<tab>bMyBool: BOOL
    bMyOtherBool: BOOL
```
But this is ok:
```
    bMyBool:<tab>BOOL
    bMyOtherBool:<tab>BOOL
```
Since not allowing this will be (has been) really disruptive