### PR TITLE
ENH: Add pre-commit CI helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ matrix:
     - name: Twincat Style
       python: 3.7
       env: TWINCAT_STYLE=1
+    - name: Pre-commit Checks
+      python: 3.7
+      env: PRE_COMMIT=1
 
 install:
   # Import the helper scripts
@@ -36,6 +39,9 @@ matrix:
     - name: Python linting
       python: 3.7
       env: LINT_PYTHON=pkg_name
+    - name: Pre-commit Checks
+      python: 3.7
+      env: PRE_COMMIT=1
 
 install:
   # Import the helper scripts

--- a/example_python_travis.yml
+++ b/example_python_travis.yml
@@ -22,6 +22,9 @@ matrix:
       env: LINT_PYTHON=pytmc
     - python: 3.6
       env: BUILD_DOCS=1
+    - name: Pre-commit Checks
+      python: 3.7
+      env: PRE_COMMIT=1
     - python: 3.7
 
 install:

--- a/example_twincat_travis.yml
+++ b/example_twincat_travis.yml
@@ -16,6 +16,8 @@ matrix:
       env: TWINCAT_BUILD_DOCS=1
     - name: Twincat Style
       env: TWINCAT_STYLE=1
+    - name: Pre-commit Checks
+      env: PRE_COMMIT=1
 
 install:
   - git clone --depth 1 git://github.com/pcdshub/pcds-ci-helpers.git

--- a/travis/init.sh
+++ b/travis/init.sh
@@ -36,5 +36,9 @@ if [[ ! -z "$TWINCAT_STYLE" ]]; then
     exit $exit_code
 fi
 
+if [[ ! -z "$PRE_COMMIT" ]]; then
+    source pre_commit.sh
+fi
+
 popd
 popd

--- a/travis/pre_commit.sh
+++ b/travis/pre_commit.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+echo ""
 echo "===================================================="
 echo "Running this library's configured pre-commit checks."
 echo "See https://pre-commit.com/ for more information."
 echo "===================================================="
+echo ""
 
 pip install pre-commit
 pre-commit install
@@ -14,6 +16,7 @@ PRE_COMMIT_EXIT_CODE=$?
 popd
 
 if [ $PRE_COMMIT_EXIT_CODE -ne 0 ]; then
+    echo ""
     echo "====================================================================="
     echo "WARNING: One or more pre-commit checks have failed!"
     echo "This means you do not have pre-commit set up in your local checkout!"
@@ -21,6 +24,7 @@ if [ $PRE_COMMIT_EXIT_CODE -ne 0 ]; then
     echo "or use the above output and the following diff to fix the issues"
     echo "manually:"
     echo "====================================================================="
+    echo ""
     echo "git diff:"
     git diff
 fi

--- a/travis/pre_commit.sh
+++ b/travis/pre_commit.sh
@@ -24,7 +24,6 @@ if [ $PRE_COMMIT_EXIT_CODE -ne 0 ]; then
     echo "manually:"
     echo "====================================================================="
     echo ""
-    echo "git diff:"
     git diff
 fi
 

--- a/travis/pre_commit.sh
+++ b/travis/pre_commit.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "===================================================="
+echo "Running this library's configured pre-commit checks."
+echo "See https://pre-commit.com/ for more information."
+echo "===================================================="
+
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
+PRE_COMMIT_EXIT_CODE=$?
+
+if [ $PRE_COMMIT_EXIT_CODE -ne 0 ]; then
+    echo "====================================================================="
+    echo "WARNING: One or more pre-commit checks have failed!"
+    echo "This means you do not have pre-commit set up in your local checkout!"
+    echo "See https://github.com/pcdshub/pre-commit-hooks/blob/master/README.md"
+    echo "or use the above output and the following diff to fix the issues"
+    echo "manually:"
+    echo "====================================================================="
+    echo "git diff:"
+    git diff
+fi
+
+exit $PRE_COMMIT_EXIT_CODE

--- a/travis/pre_commit.sh
+++ b/travis/pre_commit.sh
@@ -13,7 +13,6 @@ pre-commit install
 pushd "${TRAVIS_BUILD_DIR}"
 pre-commit run --all-files
 PRE_COMMIT_EXIT_CODE=$?
-popd
 
 if [ $PRE_COMMIT_EXIT_CODE -ne 0 ]; then
     echo ""
@@ -29,4 +28,5 @@ if [ $PRE_COMMIT_EXIT_CODE -ne 0 ]; then
     git diff
 fi
 
+popd
 exit $PRE_COMMIT_EXIT_CODE

--- a/travis/pre_commit.sh
+++ b/travis/pre_commit.sh
@@ -7,8 +7,11 @@ echo "===================================================="
 
 pip install pre-commit
 pre-commit install
+
+pushd "${TRAVIS_BUILD_DIR}"
 pre-commit run --all-files
 PRE_COMMIT_EXIT_CODE=$?
+popd
 
 if [ $PRE_COMMIT_EXIT_CODE -ne 0 ]; then
     echo "====================================================================="


### PR DESCRIPTION
Adds a new option to check the pre-commit on Travis by setting `PRE_COMMIT=1`.
Based on https://github.com/pcdshub/pre-commit-hooks/issues/4
closes #12 

In addition to the above:
- Provides links for people not familiar with pre-commit to read the docs or set up their repo
- Shows a git diff after a pre-commit failure to make it clear what needs to be fixed

Example succeeding build: https://travis-ci.org/github/ZLLentz/lcls2-cc-lib/jobs/678286604
Example failing build: https://travis-ci.org/github/ZLLentz/lcls2-cc-lib/jobs/678288717