### PR TITLE
BUG: Re-add support for old lint variable

### DIFF
--- a/travis/init.sh
+++ b/travis/init.sh
@@ -10,6 +10,13 @@ pushd travis
 
 source settings.sh
 
+if [[ ! -z "$LINT_PYTHON" ]]; then
+    cat <<EOF 1>&2
+    WARNING: The variable LINT_PYTHON has been deprecated.
+    Please instead use the new variable PYTHON_LINT_OPTIONS.
+EOF
+fi
+
 if [[ ! -z "${PYTHON_LINT_OPTIONS:=$LINT_PYTHON}" ]]; then
     source python_linter.sh
 fi

--- a/travis/init.sh
+++ b/travis/init.sh
@@ -10,7 +10,7 @@ pushd travis
 
 source settings.sh
 
-if [[ ! -z "$PYTHON_LINT_OPTIONS" ]]; then
+if [[ ! -z "${PYTHON_LINT_OPTIONS:=$LINT_PYTHON}" ]]; then
     source python_linter.sh
 fi
 


### PR DESCRIPTION
Simple fix to allow the old variable `LINT_PYTHON` to continue to be used.

Tested here: https://travis-ci.com/github/ZryletTC/typhos/jobs/338177444