### PR TITLE
MNT: allow docs template to specify requirements

### DIFF
--- a/travis/shared_configs/twincat/docs-build.yml
+++ b/travis/shared_configs/twincat/docs-build.yml
@@ -21,6 +21,10 @@ jobs:
 
         - echo "Cloning docs template from ${DOCS_TEMPLATE_URL} @ ${DOCS_TEMPLATE_BRANCH}..."
         - git clone --single-branch --branch ${DOCS_TEMPLATE_BRANCH} --depth 1 "${DOCS_TEMPLATE_URL}" ${DOCS_FOLDER}
+        - |
+          if [ -f "${DOCS_FOLDER}/requirements.txt" ]; then
+            pip install --requirement "${DOCS_FOLDER}/requirements.txt"
+          fi
 
       script:
         - export SOLUTION="$(find . -iname '*.sln')"


### PR DESCRIPTION
Pairs with https://github.com/pcdshub/twincat-docs-template/commit/eb95404a8feca6b61ce656cc459d2f26445c643f
so we can get the readthedocs theme to replace the minimal (subjectively ugly) alabaster theme...

Example
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/5139267/85341303-adae4a80-b49c-11ea-8167-23333fafadf0.png">
