### PR TITLE
MNT: remove broken package linter from default config

### DIFF
--- a/travis/shared_configs/standard-python-conda.yml
+++ b/travis/shared_configs/standard-python-conda.yml
@@ -14,7 +14,6 @@ import:
   - travis/shared_configs/anaconda-build.yml
   - travis/shared_configs/python-tester-pip.yml
   - travis/shared_configs/python-tester-conda.yml
-  - travis/shared_configs/package-linter.yml
   - travis/shared_configs/python-linter.yml
   - travis/shared_configs/docs-build.yml
   - travis/shared_configs/pypi-upload.yml


### PR DESCRIPTION
It's not possible for packages to fix their requirements due to #40.
Remove package linter from default config until issues are addressed for all our packages.