### PR TITLE
HACK/FIX: Force updating pyparsing for Docs Deploy

### DIFF
--- a/travis/shared_configs/doctr-upload.yml
+++ b/travis/shared_configs/doctr-upload.yml
@@ -12,6 +12,7 @@ jobs:
         (branch = master OR tag IS present)
       install:
         pip install doctr doctr-versions-menu
+        pip install pyparsing --upgrade
       script:
         - |
           if [[ ! -z "$DOCTR_VERSIONS_MENU" ]]; then


### PR DESCRIPTION
This is a fix for the issue that we are having with `doctr-versions-menu` reported here:
- https://github.com/pcdshub/typhos/issues/375
and here:
- https://github.com/goerz/doctr_versions_menu/issues/8

We can remove this forced upgrade to `pyparsing` once the new dependency restriction is added into the package.

I tested this with testproject1234 and it works as expected: https://travis-ci.com/github/hhslepicka/testproject1234/jobs/366840848
