### PR TITLE
MNT: Set channel_priority to strict

### DIFF
--- a/travis/shared_configs/anaconda-build.yml
+++ b/travis/shared_configs/anaconda-build.yml
@@ -14,6 +14,7 @@ jobs:
           - bash miniconda.sh -b -p $HOME/miniconda
           - export PATH="$HOME/miniconda/bin:$PATH"
           - conda config --set always_yes yes --set changeps1 no
+          - conda config --set channel_priority strict
           - conda config --add channels pcds-tag
           - conda config --add channels conda-forge
           - conda config --remove channels defaults

--- a/travis/shared_configs/anaconda-build.yml
+++ b/travis/shared_configs/anaconda-build.yml
@@ -23,6 +23,7 @@ jobs:
           - conda update -q conda conda-build
           # Useful for debugging
           - conda info -a
+          - conda config --show
 
 
         script:

--- a/travis/shared_configs/docs-build.yml
+++ b/travis/shared_configs/docs-build.yml
@@ -23,6 +23,7 @@ jobs:
         - conda config --add channels "file://`pwd`/bld-dir"
         # Useful for debugging
         - conda info -a
+        - conda config --show
         - echo "Conda Environment Name':' ${CONDA_ENV_NAME:=testenv}"
         # Manage conda environment
         - conda create -n ${CONDA_ENV_NAME} python=$PYTHON_VERSION ${CONDA_PACKAGE} ${CONDA_EXTRAS}

--- a/travis/shared_configs/docs-build.yml
+++ b/travis/shared_configs/docs-build.yml
@@ -16,6 +16,7 @@ jobs:
         - bash miniconda.sh -b -p $HOME/miniconda
         - export PATH="$HOME/miniconda/bin:$PATH"
         - conda config --set always_yes yes --set changeps1 no
+        - conda config --set channel_priority strict
         - conda config --remove channels defaults
         - conda config --add channels pcds-tag
         - conda config --add channels conda-forge

--- a/travis/shared_configs/python-benchmark.yml
+++ b/travis/shared_configs/python-benchmark.yml
@@ -14,6 +14,7 @@ jobs:
           - bash miniconda.sh -b -p $HOME/miniconda
           - export PATH="$HOME/miniconda/bin:$PATH"
           - conda config --set always_yes yes --set changeps1 no
+          - conda config --set channel_priority strict
           - conda config --add channels pcds-tag
           - conda config --add channels conda-forge
           - conda config --remove channels defaults

--- a/travis/shared_configs/python-benchmark.yml
+++ b/travis/shared_configs/python-benchmark.yml
@@ -21,6 +21,7 @@ jobs:
           - conda config --add channels "file://`pwd`/bld-dir"
           # Useful for debugging
           - conda info -a
+          - conda config --show
           - echo "Conda Environment Name':' ${CONDA_ENV_NAME:=testenv}"
           - echo "Conda Requirements':' ${CONDA_REQUIREMENTS:=dev-requirements.txt}"
 

--- a/travis/shared_configs/python-tester-conda.yml
+++ b/travis/shared_configs/python-tester-conda.yml
@@ -15,6 +15,7 @@ jobs:
         - bash miniconda.sh -b -p $HOME/miniconda
         - export PATH="$HOME/miniconda/bin:$PATH"
         - conda config --set always_yes yes --set changeps1 no
+        - conda config --set channel_priority strict
         - conda config --add channels pcds-tag
         - conda config --add channels conda-forge
         - conda config --remove channels defaults

--- a/travis/shared_configs/python-tester-conda.yml
+++ b/travis/shared_configs/python-tester-conda.yml
@@ -22,6 +22,7 @@ jobs:
         - conda config --add channels "file://`pwd`/bld-dir"
         # Useful for debugging
         - conda info -a
+        - conda config --show
         - echo "Conda Environment Name':' ${CONDA_ENV_NAME:=testenv}"
         - echo "Conda Requirements':' ${CONDA_REQUIREMENTS:=dev-requirements.txt}"
 


### PR DESCRIPTION
This ensures that we always get the correct priority e.g.:
bld-dir > conda-forge > pcds-tag

https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority

Is there any easy way to test this on my failing repo before merging here?