### PR TITLE
CI: build docs on 3.7, not 3.9

### DIFF
--- a/travis/shared_configs/docs-build.yml
+++ b/travis/shared_configs/docs-build.yml
@@ -3,7 +3,9 @@ version: ~> 1.0
 jobs:
   include:
     - stage: test
-      name: "Docs Build"
+      name: "Docs Build (Python 3.7)"
+      env:
+        - PYTHON_VERSION: 3.7
       workspaces:
         create:
           name: docs


### PR DESCRIPTION
Closes #54 