### PR TITLE
CI: docs on Python 3.6, not 3.7

### DIFF
--- a/travis/shared_configs/docs-build.yml
+++ b/travis/shared_configs/docs-build.yml
@@ -3,9 +3,9 @@ version: ~> 1.0
 jobs:
   include:
     - stage: test
-      name: "Docs Build (Python 3.7)"
+      name: "Docs Build (Python 3.6)"
       env:
-        - PYTHON_VERSION: 3.7
+        - PYTHON_VERSION: 3.6
       workspaces:
         create:
           name: docs


### PR DESCRIPTION
~`3.7`~ **3.6**