### PR TITLE
CI: build docs on 3.8

### DIFF
--- a/travis/shared_configs/docs-build.yml
+++ b/travis/shared_configs/docs-build.yml
@@ -3,9 +3,9 @@ version: ~> 1.0
 jobs:
   include:
     - stage: test
-      name: "Docs Build (Python 3.6)"
+      name: "Docs Build (Python 3.8)"
       env:
-        - PYTHON_VERSION: 3.6
+        - PYTHON_VERSION: 3.8
       workspaces:
         create:
           name: docs


### PR DESCRIPTION
Closes #60 

This may break building docs on certain repositories. As we are committed to 3.8 as our primary env target (as in `pcds-4.0.0`), we should focus on fixing those that break.

This doesn't have to be merged _now_, though. We should probably merge it when we have time to fix whatever it may break.