### PR TITLE
MNT: drop py36, default py38, add py39

### DIFF
--- a/travis/shared_configs/anaconda-upload.yml
+++ b/travis/shared_configs/anaconda-upload.yml
@@ -11,7 +11,7 @@ jobs:
         env(CONDA_UPLOAD_TOKEN_DEV) IS present AND \
         (branch = master OR \
         (branch = tag AND env(CONDA_UPLOAD_TOKEN_TAG) IS present))
-      python: 3.7
+      python: 3.8
       install: skip
       before_script:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/travis/shared_configs/docs-build.yml
+++ b/travis/shared_configs/docs-build.yml
@@ -3,9 +3,9 @@ version: ~> 1.0
 jobs:
   include:
     - stage: test
-      name: "Docs Build (Python 3.6)"
+      name: "Docs Build (Python 3.8)"
       env:
-        - PYTHON_VERSION: 3.6
+        - PYTHON_VERSION: 3.8
       workspaces:
         create:
           name: docs

--- a/travis/shared_configs/doctr-upload.yml
+++ b/travis/shared_configs/doctr-upload.yml
@@ -4,7 +4,7 @@ jobs:
   include:
     - stage: deploy
       name: "Docs Upload"
-      python: 3.6
+      python: 3.8
       workspaces:
         use: docs
       if: |

--- a/travis/shared_configs/package-linter.yml
+++ b/travis/shared_configs/package-linter.yml
@@ -2,7 +2,7 @@ jobs:
   include:
     - stage: test
       name: "Package Linter"
-      python: 3.6
+      python: 3.8
       install:
         - pip install --upgrade pip
         #- pip install pcdsutils

--- a/travis/shared_configs/python-benchmark.yml
+++ b/travis/shared_configs/python-benchmark.yml
@@ -5,7 +5,7 @@ jobs:
       - stage: test
         name: "Benchmark"
         env:
-          - PYTHON_VERSION: ${BENCHMARK_PYTHON:=3.6}
+          - PYTHON_VERSION: ${BENCHMARK_PYTHON:=3.8}
         workspaces:
           use: conda
         install: skip

--- a/travis/shared_configs/python-tester-conda.yml
+++ b/travis/shared_configs/python-tester-conda.yml
@@ -4,9 +4,9 @@ jobs:
   include:
     - &testpythonconda
       stage: test
-      name: "Python 3.6"
+      name: "Python 3.7"
       env:
-        - PYTHON_VERSION: 3.6
+        - PYTHON_VERSION: 3.7.3
       workspaces:
         use: conda
       install: skip
@@ -49,10 +49,10 @@ jobs:
               fi
           fi
     - <<: *testpythonconda
-      name: "Python 3.7"
-      env:
-        - PYTHON_VERSION: 3.7.3
-    - <<: *testpythonconda
       name: "Python 3.8"
       env:
         - PYTHON_VERSION: 3.8
+    - <<: *testpythonconda
+      name: "Python 3.9"
+      env:
+        - PYTHON_VERSION: 3.9

--- a/travis/shared_configs/python-tester-conda.yml
+++ b/travis/shared_configs/python-tester-conda.yml
@@ -6,7 +6,7 @@ jobs:
       stage: test
       name: "Python 3.7"
       env:
-        - PYTHON_VERSION: 3.7.3
+        - PYTHON_VERSION: 3.7
       workspaces:
         use: conda
       install: skip

--- a/travis/shared_configs/python-tester-pip.yml
+++ b/travis/shared_configs/python-tester-pip.yml
@@ -1,8 +1,8 @@
 jobs:
   include:
     - stage: build
-      name: "Python 3.6 - PIP"
-      python: 3.6
+      name: "Python 3.8 - PIP"
+      python: 3.8
       install:
         - pip install --upgrade pip
         - echo "Req File':' ${REQUIREMENTS:=requirements.txt}"


### PR DESCRIPTION
- As per NEP29, we could have dropped py36 support as early as last year: https://numpy.org/neps/nep-0029-deprecation_policy.html
- python 3.6 does not have dataclasses
- python 3.8 is live on the floor
- python 3.9 exists and I'd like to make it live on the floor at some point

Tried this on typhos at https://travis-ci.com/github/pcdshub/typhos/builds/232184349

Closes #61 (contains it basically)
Closes #60