### PR TITLE
ENH: push pip testing forward a bit, future-proof the build stage name

### DIFF
--- a/travis/shared_configs/python-tester-pip.yml
+++ b/travis/shared_configs/python-tester-pip.yml
@@ -1,8 +1,8 @@
 jobs:
   include:
     - stage: build
-      name: "Python 3.8 - PIP"
-      python: 3.8
+      name: "Python - PIP"
+      python: 3.9
       install:
         - pip install --upgrade pip
         - echo "Req File':' ${REQUIREMENTS:=requirements.txt}"


### PR DESCRIPTION
- Use python 3.9 in the CI pip testing, because that's what we're running in prod now
- Change the stage name to "Python - PIP" because for the builds that allow failures on PIP it's annoying to change the string every time.