### PR TITLE
CI: Various updates for pcdsdevices CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ env:
 
 jobs:
   allow_failures:
-    # This makes the PIP based Python 3.6 optional for passing.
+    # This makes the PIP based tests optional for passing.
     # Remove this block if passing tests with PIP is mandatory for your
     # package
-    - name: "Python 3.6 - PIP"
+    - name: "Python - PIP"
 
 import:
   # If your project requires X11 leave the following import
@@ -209,8 +209,8 @@ This import enables a set of standard python jobs including:
    - Python Linter
    - Package Linter
    - Documentation
-   - Python 3.6 - PIP based
-   - Python 3.6, 3.7 & 3.8 - Conda base
+   - Python 3.9 - PIP based
+   - Python 3.7, 3.8 & 3.9 - Conda base
  - Deploy Stage
    - Documentation using doctr
    - Conda Package - uploaded to pcds-dev and pcds-tag

--- a/travis/shared_configs/docs-build.yml
+++ b/travis/shared_configs/docs-build.yml
@@ -3,9 +3,9 @@ version: ~> 1.0
 jobs:
   include:
     - stage: test
-      name: "Docs Build (Python 3.8)"
+      name: "Docs Build"
       env:
-        - PYTHON_VERSION: 3.8
+        - PYTHON_VERSION: 3.9
       workspaces:
         create:
           name: docs

--- a/travis/shared_configs/python-tester-conda-latest.yml
+++ b/travis/shared_configs/python-tester-conda-latest.yml
@@ -1,12 +1,13 @@
 version: ~> 1.0
-# Run conda tests on all versions from NEP 29
+
+# Run conda tests on the prod pcds python version and later
+
 jobs:
   include:
-    - &testpythonconda
-      stage: test
-      name: "Python 3.7"
+    - stage: test
+      name: "Python 3.9"
       env:
-        - PYTHON_VERSION: 3.7
+        - PYTHON_VERSION: 3.9
       workspaces:
         use: conda
       install: skip
@@ -48,11 +49,3 @@ jobs:
                   python -m pytest
               fi
           fi
-    - <<: *testpythonconda
-      name: "Python 3.8"
-      env:
-        - PYTHON_VERSION: 3.8
-    - <<: *testpythonconda
-      name: "Python 3.9"
-      env:
-        - PYTHON_VERSION: 3.9

--- a/travis/shared_configs/python-tester-conda-latest.yml
+++ b/travis/shared_configs/python-tester-conda-latest.yml
@@ -1,7 +1,5 @@
 version: ~> 1.0
-
 # Run conda tests on the prod pcds python version and later
-
 jobs:
   include:
     - stage: test

--- a/travis/shared_configs/standard-python-conda-latest.yml
+++ b/travis/shared_configs/standard-python-conda-latest.yml
@@ -1,0 +1,21 @@
+version: ~> 1.0
+
+language: python
+os: linux
+dist: xenial
+
+stages:
+  - build
+  - test
+  - name: deploy
+    if: (branch = master OR tag IS present) AND type != pull_request
+
+import:
+  - travis/shared_configs/anaconda-build.yml
+  - travis/shared_configs/python-tester-pip.yml
+  - travis/shared_configs/python-tester-conda-latest.yml
+  - travis/shared_configs/python-linter.yml
+  - travis/shared_configs/docs-build.yml
+  - travis/shared_configs/pypi-upload.yml
+  - travis/shared_configs/doctr-upload.yml
+  - travis/shared_configs/anaconda-upload.yml


### PR DESCRIPTION
`pcdsdevices` is the first module that is going 3.9 only (admittedly, mostly because it can and also because I want free reign to use all new language features). Here are some adjustments to the CI to accommodate this.

- Move Sphinx docs to Python 3.9. This allows packages that are 3.9-only to run docs builds.
- Add standard option for testing with prod python and up only. This allows packages that are 3.9-only to run their CI without any extra allow_failures builds.
- Adjust some information in the readme because I noticed it was outdated while scrolling through.