### PR TITLE
CI: run the python linter against py3.9

### DIFF
--- a/travis/shared_configs/python-linter.yml
+++ b/travis/shared_configs/python-linter.yml
@@ -2,6 +2,7 @@ jobs:
   include:
     - stage: test
       name: "Python Linter"
+      python: 3.9
       install:
         - pip install flake8
       before_script:


### PR DESCRIPTION
I have a job that's failing because I have code that throws a syntax error on python versions before 3.8, and is picked up as such by the python 3.6 flake8 that travis is running. It creates a funny build where all the tests pass, and then I'm also alerted about a syntax error.

This changes the python linter config to run on python 3.9 instead of on the default travis python version, which is apparently 3.6