### PR TITLE
CI: by default, start up the X server

### DIFF
--- a/travis/shared_configs/standard-python-conda-latest.yml
+++ b/travis/shared_configs/standard-python-conda-latest.yml
@@ -11,6 +11,7 @@ stages:
     if: (branch = master OR tag IS present) AND type != pull_request
 
 import:
+  - travis/shared_configs/setup-env-ui.yml
   - travis/shared_configs/anaconda-build.yml
   - travis/shared_configs/python-tester-pip.yml
   - travis/shared_configs/python-tester-conda-latest.yml

--- a/travis/shared_configs/standard-python-conda.yml
+++ b/travis/shared_configs/standard-python-conda.yml
@@ -11,6 +11,7 @@ stages:
     if: (branch = master OR tag IS present) AND type != pull_request
 
 import:
+  - travis/shared_configs/setup-env-ui.yml
   - travis/shared_configs/anaconda-build.yml
   - travis/shared_configs/python-tester-pip.yml
   - travis/shared_configs/python-tester-conda.yml


### PR DESCRIPTION
X server and window manager can be confusing if forgotten, leading to segfaulting CI failures.
I'm voting to take the CI performance hit and just run our ui setup by default.

I think these imports should do it - what do you think, @ZLLentz @ZryletTC ?