### PR TITLE
MAINT: set MPLBACKEND=agg for pip

### DIFF
--- a/travis/shared_configs/python-tester-pip.yml
+++ b/travis/shared_configs/python-tester-pip.yml
@@ -3,6 +3,7 @@ jobs:
     - stage: build
       name: "Python - PIP"
       python: 3.9
+      env: MPLBACKEND=agg
       install:
         - pip install --upgrade pip
         - echo "Req File':' ${REQUIREMENTS:=requirements.txt}"


### PR DESCRIPTION
Set the matplotlib backend to avoid unknown pyqt/bluesky bug in the pip builds

These have been failing with cryptic abort messages that seem related to a strange background thread interaction between these libraries on these builds during unit testing suites only on travis only