### PR TITLE
MNT: force py39 for pypi upload build for new script reqs

### DIFF
--- a/travis/shared_configs/pypi-upload.yml
+++ b/travis/shared_configs/pypi-upload.yml
@@ -2,6 +2,7 @@ jobs:
   include:
     - stage: deploy
       name: "PyPI Upload"
+      python: 3.9
       script: skip
       before_install: skip
       install: skip


### PR DESCRIPTION
Context
```
Successfully installed dpl-pypi-1.10.16
1 gem installed
2022-06-02 22:37:44 URL:https://bootstrap.pypa.io/get-pip.py [2680354/2680354] -> "-" [1]
ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead.
Couldn't install pip, setuptools, twine or wheel.
```