### PR TITLE
MAINT: drop py37 builds as per NEP29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: xenial
 jobs:
   include:
     - name: Pre-commit Checks
-      python: 3.7
+      python: 3.9
       env: PRE_COMMIT=1
 
 install:

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ import:
   # - Tests
   #   - Linter
   #   - Documentation
-  #   - Python 3.6 - PIP based
-  #   - Python 3.6, 3.7 & 3.8 - Conda base
+  #   - Python 3.9 - PIP based
+  #   - Python 3.8 & 3.9 - Conda based
   # - Deploy
   #   - Documentation using doctr
   #   - Conda Package - uploaded to pcds-dev and pcds-tag
@@ -210,7 +210,7 @@ This import enables a set of standard python jobs including:
    - Package Linter
    - Documentation
    - Python 3.9 - PIP based
-   - Python 3.7, 3.8 & 3.9 - Conda base
+   - Python 3.8 & 3.9 - Conda base
  - Deploy Stage
    - Documentation using doctr
    - Conda Package - uploaded to pcds-dev and pcds-tag
@@ -261,7 +261,7 @@ import:
 
 #### shared_configs/python-tester-pip.yml
 `python-tester-pip.yml` runs any pytest tests it finds after installing the
-specified requirements via PIP using Python 3.6.
+specified requirements via PIP.
 
 ##### usage:
 This configuration can be added to the `build` stage of a Travis build by
@@ -325,7 +325,7 @@ import:
 #### shared_configs/python-tester-conda.yml
 `python-tester-conda.yml` runs any pytest tests it finds after installing the
 specified requirements via conda.
-The current test matrix includes Python 3.6, 3.7 and 3.8.
+The current test matrix includes Python 3.8 and 3.9.
 This job uses the workspace named `conda` for access to the `noarch`
 package previously built by the `anaconda-build.yml`, and thus must be
 used in conjuction with `anaconda-build.yml`.

--- a/example_python_travis.yml
+++ b/example_python_travis.yml
@@ -35,10 +35,10 @@ env:
 # failure
 #jobs:
 #  allow_failures:
-#    # This makes the PIP based Python 3.6 optional for passing.
+#    # This makes the PIP based Python optional for passing.
 #    # Remove this block if passing tests with PIP is mandatory for your
 #    # package
-#    - name: "Python 3.6 - PIP"
+#    - name: "Python - PIP"
 
 import:
   # If your project requires X11 leave the following import
@@ -50,8 +50,8 @@ import:
   #   - Python Linter
   #   - Package Linter
   #   - Documentation
-  #   - Python 3.6 - PIP based
-  #   - Python 3.6, 3.7 & 3.8 - Conda base
+  #   - Python 3.9 - PIP based
+  #   - Python 3.8 & 3.9 - Conda based
   # - Deploy
   #   - Documentation using doctr
   #   - Conda Package - uploaded to pcds-dev and pcds-tag

--- a/travis/shared_configs/python-tester-conda.yml
+++ b/travis/shared_configs/python-tester-conda.yml
@@ -4,9 +4,9 @@ jobs:
   include:
     - &testpythonconda
       stage: test
-      name: "Python 3.7"
+      name: "Python 3.8"
       env:
-        - PYTHON_VERSION: 3.7
+        - PYTHON_VERSION: 3.8
       workspaces:
         use: conda
       install: skip
@@ -61,10 +61,6 @@ jobs:
           else
             echo "Logfile ${LOGFILE} not found"
           fi
-    - <<: *testpythonconda
-      name: "Python 3.8"
-      env:
-        - PYTHON_VERSION: 3.8
     - <<: *testpythonconda
       name: "Python 3.9"
       env:


### PR DESCRIPTION
https://numpy.org/neps/nep-0029-deprecation_policy.html

Admittedly this is entirely because py37 is segfaulting for typhos in the CI