### PR TITLE
REF: try pytest-cov instead of using 'coverage run'

### DIFF
--- a/travis/shared_configs/python-tester-conda-latest.yml
+++ b/travis/shared_configs/python-tester-conda-latest.yml
@@ -38,7 +38,12 @@ jobs:
         # Useful for debugging
         - micromamba list
       script:
-        - python -m pytest --cov=.
+        - python -m pytest \
+            --cov=. \
+            --log-file="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}" \
+            --log-file-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s' \
+            --log-file-date-format='%H:%M:%S' \
+            --log-level=DEBUG
       after_failure:
         - LOGFILE="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"
         - |

--- a/travis/shared_configs/python-tester-conda-latest.yml
+++ b/travis/shared_configs/python-tester-conda-latest.yml
@@ -31,18 +31,18 @@ jobs:
         - echo "Conda Environment Name':' ${CONDA_ENV_NAME:=testenv}"
         - echo "Conda Requirements':' ${CONDA_REQUIREMENTS:=dev-requirements.txt}"
         - echo "Conda packages installed for CI':' ${CONDA_CI_PACKAGES:=pytest-cov}"
-
         # Manage conda environment
         - micromamba create -n ${CONDA_ENV_NAME} python=$PYTHON_VERSION ${CONDA_PACKAGE} ${CONDA_EXTRAS} ${CONDA_CI_PACKAGES} --file ${CONDA_REQUIREMENTS}
         - micromamba activate ${CONDA_ENV_NAME}
         # Useful for debugging
         - micromamba list
       script:
-        - python -m pytest \
-            --cov=. \
-            --log-file="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}" \
-            --log-file-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s' \
-            --log-file-date-format='%H:%M:%S' \
+        - >
+          python -m pytest --
+            --cov=.
+            --log-file="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"
+            --log-file-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s'
+            --log-file-date-format='%H:%M:%S'
             --log-level=DEBUG
       after_failure:
         - LOGFILE="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"

--- a/travis/shared_configs/python-tester-conda-latest.yml
+++ b/travis/shared_configs/python-tester-conda-latest.yml
@@ -30,28 +30,15 @@ jobs:
         - micromamba config list
         - echo "Conda Environment Name':' ${CONDA_ENV_NAME:=testenv}"
         - echo "Conda Requirements':' ${CONDA_REQUIREMENTS:=dev-requirements.txt}"
+        - echo "Conda packages installed for CI':' ${CONDA_CI_PACKAGES:=pytest-cov}"
 
         # Manage conda environment
-        - micromamba create -n ${CONDA_ENV_NAME} python=$PYTHON_VERSION ${CONDA_PACKAGE} ${CONDA_EXTRAS} --file ${CONDA_REQUIREMENTS}
+        - micromamba create -n ${CONDA_ENV_NAME} python=$PYTHON_VERSION ${CONDA_PACKAGE} ${CONDA_EXTRAS} ${CONDA_CI_PACKAGES} --file ${CONDA_REQUIREMENTS}
         - micromamba activate ${CONDA_ENV_NAME}
         # Useful for debugging
         - micromamba list
       script:
-        - |
-          if command -v coverage; then
-              if [ -f "run_tests.py" ]; then
-                  coverage run --concurrency=thread --parallel-mode run_tests.py
-              else
-                  coverage run --concurrency=thread --parallel-mode -m pytest
-              fi
-              (coverage combine && coverage report | grep -v -e ' 0%') || true
-          else
-              if [ -f "run_tests.py" ]; then
-                  python run_tests.py
-              else
-                  python -m pytest
-              fi
-          fi
+        - python -m pytest --cov=.
       after_failure:
         - LOGFILE="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"
         - |

--- a/travis/shared_configs/python-tester-conda.yml
+++ b/travis/shared_configs/python-tester-conda.yml
@@ -31,6 +31,7 @@ jobs:
         - micromamba config list
         - echo "Conda Environment Name':' ${CONDA_ENV_NAME:=testenv}"
         - echo "Conda Requirements':' ${CONDA_REQUIREMENTS:=dev-requirements.txt}"
+        - echo "Conda packages installed for CI':' ${CONDA_CI_PACKAGES:=pytest-cov}"
 
         # Manage conda environment
         - micromamba create -n ${CONDA_ENV_NAME} python=$PYTHON_VERSION ${CONDA_PACKAGE} ${CONDA_EXTRAS} --file ${CONDA_REQUIREMENTS}
@@ -38,21 +39,7 @@ jobs:
         # Useful for debugging
         - micromamba list
       script:
-        - |
-          if command -v coverage; then
-              if [ -f "run_tests.py" ]; then
-                  coverage run --concurrency=thread --parallel-mode run_tests.py
-              else
-                  coverage run --concurrency=thread --parallel-mode -m pytest
-              fi
-              (coverage combine && coverage report | grep -v -e ' 0%') || true
-          else
-              if [ -f "run_tests.py" ]; then
-                  python run_tests.py
-              else
-                  python -m pytest
-              fi
-          fi
+        - python -m pytest --cov=.
       after_failure:
         - LOGFILE="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"
         - |

--- a/travis/shared_configs/python-tester-conda.yml
+++ b/travis/shared_configs/python-tester-conda.yml
@@ -39,7 +39,12 @@ jobs:
         # Useful for debugging
         - micromamba list
       script:
-        - python -m pytest --cov=.
+        - python -m pytest \
+            --cov=. \
+            --log-file="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}" \
+            --log-file-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s' \
+            --log-file-date-format='%H:%M:%S' \
+            --log-level=DEBUG
       after_failure:
         - LOGFILE="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"
         - |

--- a/travis/shared_configs/python-tester-conda.yml
+++ b/travis/shared_configs/python-tester-conda.yml
@@ -32,18 +32,18 @@ jobs:
         - echo "Conda Environment Name':' ${CONDA_ENV_NAME:=testenv}"
         - echo "Conda Requirements':' ${CONDA_REQUIREMENTS:=dev-requirements.txt}"
         - echo "Conda packages installed for CI':' ${CONDA_CI_PACKAGES:=pytest-cov}"
-
         # Manage conda environment
         - micromamba create -n ${CONDA_ENV_NAME} python=$PYTHON_VERSION ${CONDA_PACKAGE} ${CONDA_EXTRAS} --file ${CONDA_REQUIREMENTS}
         - micromamba activate ${CONDA_ENV_NAME}
         # Useful for debugging
         - micromamba list
       script:
-        - python -m pytest \
-            --cov=. \
-            --log-file="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}" \
-            --log-file-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s' \
-            --log-file-date-format='%H:%M:%S' \
+        - >
+          python -m pytest --
+            --cov=.
+            --log-file="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"
+            --log-file-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s'
+            --log-file-date-format='%H:%M:%S'
             --log-level=DEBUG
       after_failure:
         - LOGFILE="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"

--- a/travis/shared_configs/python-tester-pip.yml
+++ b/travis/shared_configs/python-tester-pip.yml
@@ -38,7 +38,12 @@ jobs:
               pip install ${PIP_CI_PACKAGES}
           fi
       script:
-        - python -m pytest --cov=.
+        - python -m pytest \
+            --cov=. \
+            --log-file="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}" \
+            --log-file-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s' \
+            --log-file-date-format='%H:%M:%S' \
+            --log-level=DEBUG
       after_failure:
         - LOGFILE="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"
         - |

--- a/travis/shared_configs/python-tester-pip.yml
+++ b/travis/shared_configs/python-tester-pip.yml
@@ -8,6 +8,7 @@ jobs:
         - pip install --upgrade pip
         - echo "Req File':' ${REQUIREMENTS:=requirements.txt}"
         - echo "Dev Req File':' ${DEV_REQUIREMENTS:=dev-requirements.txt}"
+        - echo "Pip packages installed for CI':' ${PIP_CI_PACKAGES:=pytest-cov}"
         - |
           # Install requirements
           if [[ ! -f "${REQUIREMENTS}" ]]; then
@@ -30,22 +31,14 @@ jobs:
               echo "Installing extra pip dependencies."
               pip install ${PIP_EXTRAS}
           fi
-      script:
         - |
-          if command -v coverage; then
-              if [ -f "run_tests.py" ]; then
-                  coverage run --concurrency=thread --parallel-mode run_tests.py
-              else
-                  coverage run --concurrency=thread --parallel-mode -m pytest
-              fi
-              (coverage combine && coverage report | grep -v -e ' 0%') || true
-          else
-              if [ -f "run_tests.py" ]; then
-                  python run_tests.py
-              else
-                  python -m pytest
-              fi
+          # Install Extras such as PyQt5
+          if [[ ! -z "${PIP_CI_PACKAGES}" ]]; then
+              echo "Installing pip dependencies for CI."
+              pip install ${PIP_CI_PACKAGES}
           fi
+      script:
+        - python -m pytest --cov=.
       after_failure:
         - LOGFILE="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"
         - |

--- a/travis/shared_configs/python-tester-pip.yml
+++ b/travis/shared_configs/python-tester-pip.yml
@@ -38,11 +38,12 @@ jobs:
               pip install ${PIP_CI_PACKAGES}
           fi
       script:
-        - python -m pytest \
-            --cov=. \
-            --log-file="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}" \
-            --log-file-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s' \
-            --log-file-date-format='%H:%M:%S' \
+        - >
+          python -m pytest --
+            --cov=.
+            --log-file="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"
+            --log-file-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s'
+            --log-file-date-format='%H:%M:%S'
             --log-level=DEBUG
       after_failure:
         - LOGFILE="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"


### PR DESCRIPTION
Possible solution for #79 

~It would be nice if we had a `PYTHON_MODULE_NAME` environment variable in general. We could limit the scope of the coverage more specifically here, instead of including `setup.py` etc.~ On second thought, that probably belongs in either `.coveragerc` or `pyproject.toml`

Closes #79 