### PR TITLE
FIX: pytest_args, again

### DIFF
--- a/travis/shared_configs/python-tester-conda-latest.yml
+++ b/travis/shared_configs/python-tester-conda-latest.yml
@@ -38,12 +38,12 @@ jobs:
         - micromamba list
       script:
         - |
-          PYTEST_ARGS=("-v")
-          PYTEST_ARGS+=("--cov=.")
-          PYTEST_ARGS+=("--log-file='${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}'")
-          PYTEST_ARGS+=("--log-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s'")
-          PYTEST_ARGS+=("--log-file-date-format='%H:%M:%S'")
-          PYTEST_ARGS+=("--log-level=DEBUG")
+          PYTEST_ARGS=(-v)
+          PYTEST_ARGS+=(--cov=.)
+          PYTEST_ARGS+=(--log-file="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}")
+          PYTEST_ARGS+=(--log-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s')
+          PYTEST_ARGS+=(--log-file-date-format='%H:%M:%S')
+          PYTEST_ARGS+=(--log-level=DEBUG)
         - pytest "${PYTEST_ARGS[@]}"
       after_failure:
         - LOGFILE="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"

--- a/travis/shared_configs/python-tester-conda.yml
+++ b/travis/shared_configs/python-tester-conda.yml
@@ -39,12 +39,12 @@ jobs:
         - micromamba list
       script:
         - |
-          PYTEST_ARGS=("-v")
-          PYTEST_ARGS+=("--cov=.")
-          PYTEST_ARGS+=("--log-file='${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}'")
-          PYTEST_ARGS+=("--log-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s'")
-          PYTEST_ARGS+=("--log-file-date-format='%H:%M:%S'")
-          PYTEST_ARGS+=("--log-level=DEBUG")
+          PYTEST_ARGS=(-v)
+          PYTEST_ARGS+=(--cov=.)
+          PYTEST_ARGS+=(--log-file="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}")
+          PYTEST_ARGS+=(--log-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s')
+          PYTEST_ARGS+=(--log-file-date-format='%H:%M:%S')
+          PYTEST_ARGS+=(--log-level=DEBUG)
         - pytest "${PYTEST_ARGS[@]}"
       after_failure:
         - LOGFILE="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"

--- a/travis/shared_configs/python-tester-pip.yml
+++ b/travis/shared_configs/python-tester-pip.yml
@@ -32,7 +32,7 @@ jobs:
               pip install ${PIP_EXTRAS}
           fi
         - |
-          # Install Extras such as PyQt5
+          # Install packages required for continuous integration
           if [[ ! -z "${PIP_CI_PACKAGES}" ]]; then
               echo "Installing pip dependencies for CI."
               pip install ${PIP_CI_PACKAGES}

--- a/travis/shared_configs/python-tester-pip.yml
+++ b/travis/shared_configs/python-tester-pip.yml
@@ -39,12 +39,12 @@ jobs:
           fi
       script:
         - |
-          PYTEST_ARGS=("-v")
-          PYTEST_ARGS+=("--cov=.")
-          PYTEST_ARGS+=("--log-file='${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}'")
-          PYTEST_ARGS+=("--log-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s'")
-          PYTEST_ARGS+=("--log-file-date-format='%H:%M:%S'")
-          PYTEST_ARGS+=("--log-level=DEBUG")
+          PYTEST_ARGS=(-v)
+          PYTEST_ARGS+=(--cov=.)
+          PYTEST_ARGS+=(--log-file="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}")
+          PYTEST_ARGS+=(--log-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s')
+          PYTEST_ARGS+=(--log-file-date-format='%H:%M:%S')
+          PYTEST_ARGS+=(--log-level=DEBUG)
         - pytest "${PYTEST_ARGS[@]}"
       after_failure:
         - LOGFILE="${AFTER_FAILURE_LOGFILE:-logs/run_tests_log.txt}"


### PR DESCRIPTION
## Context

Testing lightpath failures in a docker container showed that my bash knowledge still has a way to go:
* Quotes are not required when appending to the array
* In fact, they get included as-is when running pytest
* Additionally, a mistaken single quote caused for the log filename to not be expanded