### PR TITLE
ENH: test against python 3.10

### DIFF
--- a/travis/shared_configs/python-tester-conda-latest.yml
+++ b/travis/shared_configs/python-tester-conda-latest.yml
@@ -6,7 +6,7 @@ jobs:
       stage: test
       name: "Python 3.9"
       env:
-        - PYTHON_VERSION: 3.9
+        - PYTHON_VERSION: "3.9"
         - QT_QPA_PLATFORM: offscreen
       workspaces:
         use: conda
@@ -58,6 +58,6 @@ jobs:
     - <<: *testpythonconda
       name: "Python 3.10"
       env:
-        - PYTHON_VERSION: 3.10
+        - PYTHON_VERSION: "3.10"
   allow_failures:
     - name: "Python 3.10"

--- a/travis/shared_configs/python-tester-conda-latest.yml
+++ b/travis/shared_configs/python-tester-conda-latest.yml
@@ -59,3 +59,5 @@ jobs:
       name: "Python 3.10"
       env:
         - PYTHON_VERSION: 3.10
+  allow_failures:
+    - name: "Python 3.10"

--- a/travis/shared_configs/python-tester-conda-latest.yml
+++ b/travis/shared_configs/python-tester-conda-latest.yml
@@ -2,7 +2,8 @@ version: ~> 1.0
 # Run conda tests on the prod pcds python version and later
 jobs:
   include:
-    - stage: test
+    - &testpythonconda
+      stage: test
       name: "Python 3.9"
       env:
         - PYTHON_VERSION: 3.9
@@ -54,3 +55,7 @@ jobs:
           else
             echo "Logfile ${LOGFILE} not found"
           fi
+    - <<: *testpythonconda
+      name: "Python 3.10"
+      env:
+        - PYTHON_VERSION: 3.10

--- a/travis/shared_configs/python-tester-conda.yml
+++ b/travis/shared_configs/python-tester-conda.yml
@@ -6,7 +6,7 @@ jobs:
       stage: test
       name: "Python 3.8"
       env:
-        - PYTHON_VERSION: 3.8
+        - PYTHON_VERSION: "3.8"
         - QT_QPA_PLATFORM: offscreen
       workspaces:
         use: conda
@@ -58,10 +58,10 @@ jobs:
     - <<: *testpythonconda
       name: "Python 3.9"
       env:
-        - PYTHON_VERSION: 3.9
+        - PYTHON_VERSION: "3.9"
     - <<: *testpythonconda
       name: "Python 3.10"
       env:
-        - PYTHON_VERSION: 3.10
+        - PYTHON_VERSION: "3.10"
   allow_failures:
     - name: "Python 3.10"

--- a/travis/shared_configs/python-tester-conda.yml
+++ b/travis/shared_configs/python-tester-conda.yml
@@ -59,3 +59,7 @@ jobs:
       name: "Python 3.9"
       env:
         - PYTHON_VERSION: 3.9
+    - <<: *testpythonconda
+      name: "Python 3.10"
+      env:
+        - PYTHON_VERSION: 3.10

--- a/travis/shared_configs/python-tester-conda.yml
+++ b/travis/shared_configs/python-tester-conda.yml
@@ -63,3 +63,5 @@ jobs:
       name: "Python 3.10"
       env:
         - PYTHON_VERSION: 3.10
+  allow_failures:
+    - name: "Python 3.10"


### PR DESCRIPTION
This is in preparation for the eventual upgrade to python 3.10

- Add python 3.10 test stages to the standard and latest python checkers
- Set these new stages as default/mandatory allow_failure

Once we deploy python 3.10, then the following changes could be made:
- "latest" config could stop testing on 3.9
- no more default/mandatory allow_failure on 3.10
- make the pypi build and others use 3.10 instead of 3.9