### PR TITLE
MAINT: pin packaging back for the twincat builds to avoid a removal

### DIFF
--- a/travis/shared_configs/twincat/setup.yml
+++ b/travis/shared_configs/twincat/setup.yml
@@ -26,6 +26,9 @@ jobs:
           - pip install --upgrade pip
           - pip install git+https://github.com/pcdshub/ads-deploy/
           - pip install doctr sphinx recommonmark doctr-versions-menu pre-commit
+          # packaging 22.0 breaks some builds by removing LegacyVersion.
+          # this will need to be resolved in a better way later.
+          - pip install packaging=21.3
 
           # Useful for debugging
           - conda info -a

--- a/travis/shared_configs/twincat/setup.yml
+++ b/travis/shared_configs/twincat/setup.yml
@@ -28,7 +28,7 @@ jobs:
           - pip install doctr sphinx recommonmark doctr-versions-menu pre-commit
           # packaging 22.0 breaks some builds by removing LegacyVersion.
           # this will need to be resolved in a better way later.
-          - pip install packaging=21.3
+          - pip install packaging==21.3
 
           # Useful for debugging
           - conda info -a


### PR DESCRIPTION
Closes #89

See https://app.travis-ci.com/github/pcdshub/lcls-twincat-vacuum/jobs/590814009, for example:

```
Traceback (most recent call last):
  File "/home/travis/miniconda/lib/python3.9/site-packages/sphinx/config.py", line 350, in eval_config_file
    exec(code, namespace)
  File "/home/travis/docs/source/conf.py", line 18, in <module>
    import doctr_versions_menu
  File "/home/travis/miniconda/lib/python3.9/site-packages/doctr_versions_menu/__init__.py", line 14, in <module>
    from . import cli, ext
  File "/home/travis/miniconda/lib/python3.9/site-packages/doctr_versions_menu/cli.py", line 15, in <module>
    from .version_data import get_version_data
  File "/home/travis/miniconda/lib/python3.9/site-packages/doctr_versions_menu/version_data.py", line 10, in <module>
    from .groups import get_groups
  File "/home/travis/miniconda/lib/python3.9/site-packages/doctr_versions_menu/groups.py", line 2, in <module>
    from packaging.version import LegacyVersion
ImportError: cannot import name 'LegacyVersion' from 'packaging.version' (/home/travis/miniconda/lib/python3.9/site-packages/packaging/version.py)
```