### PR TITLE
FIX: python-docs requires package-name to be set, even for twincat

### DIFF
--- a/.github/workflows/twincat-standard.yml
+++ b/.github/workflows/twincat-standard.yml
@@ -56,6 +56,7 @@ jobs:
     uses: ./.github/workflows/python-docs.yml
     with:
       deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
+      package-name: ""
       install-package: false
       docs-template-repo: "klauer/twincat-docs-template"
       docs-template-ref: "enh_update"


### PR DESCRIPTION
python-docs requires a package-name setting. 
We re-use this workflow for TwinCAT jobs which have no Python package.

* A consequence of changes in #91 
* In future, if package name gets used in `python-docs.yml`, we'll need to check that `package-name` is not empty prior to using it
* Revealed in https://github.com/pcdshub/pcds-ci-test-repo-twincat/actions/runs/3888276083