### PR TITLE
FIX: docs are in ./ and not ./html

### DIFF
--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -306,7 +306,7 @@ jobs:
           cd "$HOME/gh-pages"
           git init
         )
-        rsync -av --delete "./html/" "$HOME/gh-pages/${{ needs.build.outputs.deploy_version }}/"
+        rsync -av --delete ./ "$HOME/gh-pages/${{ needs.build.outputs.deploy_version }}/"
 
         # Run docs-versions-menu
         cd "$HOME/gh-pages"


### PR DESCRIPTION
Side-effect of #95 - docs deployment was failing.

Test repo tests indicate this works now: 
https://github.com/pcdshub/pcds-ci-test-repo-python/actions/runs/3961843579/jobs/6787770412
https://github.com/pcdshub/pcds-ci-test-repo-python/commit/4a546f778f8a988485801983f776402f3f974df9