### PR TITLE
ENH: allow system package installation in Python testing workflows

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -46,6 +46,11 @@ on:
         description: "Development requirements filename"
         required: false
         type: string
+      system-packages:
+        default: ""
+        description: "CI-specific system packages required for installation"
+        required: false
+        type: string
     outputs: {}
 
 env:
@@ -103,6 +108,11 @@ jobs:
         echo "* Conda recipe folder: ${{ inputs.recipe-folder }}"
         echo "* Conda requirements file for development: ${{ inputs.requirements-file }}"
         echo "* Micromamba environment root: ${MAMBA_ROOT_PREFIX}"
+
+    - name: Install required system packages
+      if: inputs.system-packages != ''
+      run: |
+        sudo apt-get -y install ${{ inputs.system-packages }}
 
     - name: Set up micromamba and environment
       run: |

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -57,6 +57,11 @@ on:
         description: "Development requirements filenames"
         required: false
         type: string
+      system-packages:
+        default: ""
+        description: "CI-specific system packages required for docs building"
+        required: false
+        type: string
     outputs: {}
 
 env:
@@ -127,6 +132,11 @@ jobs:
           echo "Built docs version unset? See previous step"
           exit 1
         fi
+
+    - name: Install required system packages
+      if: inputs.system-packages != ''
+      run: |
+        sudo apt-get -y install ${{ inputs.system-packages }}
 
     - name: Prepare for log files
       run: |

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -36,6 +36,11 @@ on:
         description: "Development requirements filename"
         required: false
         type: string
+      system-packages:
+        default: ""
+        description: "CI-specific system packages required for installation"
+        required: false
+        type: string
     outputs: {}
 
 env:
@@ -75,6 +80,11 @@ jobs:
         echo "* Package to be built: ${{ inputs.package-name }}"
         echo "* Pip 'extras' for CI testing: ${{ inputs.testing-extras }}"
         echo "* General pip packages required for CI testing: ${{ inputs.ci-extras }}"
+
+    - name: Install required system packages
+      if: inputs.system-packages != ''
+      run: |
+        sudo apt-get -y install ${{ inputs.system-packages }}
 
     - name: Prepare for log files
       run: |

--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -27,6 +27,21 @@ on:
         type: string
         default: ""
         description: "Extras only for pip-based testing"
+      conda-system-packages:
+        required: false
+        type: string
+        default: ""
+        description: "System packages only for conda testing"
+      pip-system-packages:
+        required: false
+        type: string
+        default: ""
+        description: "System packages only for pip-based testing"
+      docs-system-packages:
+        required: false
+        type: string
+        default: ""
+        description: "System packages only for docs, in addition to the pip ones"
       docs-organization:
         required: false
         type: string
@@ -63,6 +78,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
       experimental: ${{ matrix.experimental || false }}
       testing-extras: ${{ inputs.testing-extras }} ${{ inputs.conda-testing-extras }}
+      system-packages: ${{ inputs.conda-system-packages }}
       use-setuptools-scm: ${{ inputs.use-setuptools-scm }}
 
   pip-test:
@@ -82,6 +98,7 @@ jobs:
       package-name: ${{ inputs.package-name }}
       python-version: ${{ matrix.python-version }}
       experimental: ${{ matrix.experimental || false }}
+      system-packages: ${{ inputs.pip-system-packages }}
       testing-extras: ${{ inputs.testing-extras }} ${{ inputs.pip-testing-extras }}
 
   pip-docs:
@@ -91,3 +108,4 @@ jobs:
       package-name: ${{ inputs.package-name }}
       python-version: ${{ inputs.python-version-docs }}
       deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
+      system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}


### PR DESCRIPTION
* Add `system-packages` input to conda, pip, and docs workflows
* Add `pip-system-packages`, `conda-system-packages`, and `docs-system-packages` to standard reused Python workflow input

Used in: https://github.com/pcdshub/whatrecord/pull/152