### PR TITLE
MNT: GHA - make all checkouts recursive

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -91,6 +91,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        submodules: 'recursive'
 
     - name: Check version to be built
       run: |

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -98,6 +98,7 @@ jobs:
         repository: ${{ inputs.docs-template-repo }}
         ref: ${{ inputs.docs-template-ref }}
         path: ${{ inputs.docs-directory }}
+        submodules: 'recursive'
 
     - name: Check that the documentation directory exists
       run: |

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -66,6 +66,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        submodules: 'recursive'
 
     - name: Check version to be built
       run: |

--- a/.github/workflows/twincat-pragmalint.yml
+++ b/.github/workflows/twincat-pragmalint.yml
@@ -42,6 +42,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        submodules: 'recursive'
 
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/twincat-style.yml
+++ b/.github/workflows/twincat-style.yml
@@ -52,6 +52,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        submodules: 'recursive'
 
     - name: Find all changed files
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/twincat-summary.yml
+++ b/.github/workflows/twincat-summary.yml
@@ -37,6 +37,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        submodules: 'recursive'
 
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/twincat-syntax.yml
+++ b/.github/workflows/twincat-syntax.yml
@@ -42,6 +42,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        submodules: 'recursive'
 
     - uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
* TwinCAT repositories such as https://github.com/pcdshub/lcls-twincat-motion have submodules with library source code
* For the tools to have a full view of all enclosed source code, we need to make all checkouts recursive for TwinCAT jobs
* We typically don't use submodules in our Python repositories, but it seems a reasonable default to use regardless