### PR TITLE
REF: replace find-with-or with function

### DIFF
--- a/.github/workflows/twincat-pragmalint.yml
+++ b/.github/workflows/twincat-pragmalint.yml
@@ -94,12 +94,6 @@ jobs:
           echo ""
         ) | tee -a "$GITHUB_STEP_SUMMARY"
 
-        find_source_code_files() {
-          find "${{ inputs.project-root }}" -type f -iname '*.TcDUT' -print0
-          find "${{ inputs.project-root }}" -type f -iname '*.TcGVL' -print0
-          find "${{ inputs.project-root }}" -type f -iname '*.TcPOU' -print0
-        }
-
         while IFS= read -r -d '' source_filename; do
           # Show details in the GitHub Actions output
           echo "Checking ${source_filename}"
@@ -115,7 +109,7 @@ jobs:
             echo "Pragma lint failed. Setting error code." >/dev/stderr
             EXIT_CODE=1
           fi
-        done < <(find_source_code_files)
+        done < <(find "${{ inputs.project-root }}" -type f \( -iname '*.TcDUT' -or -iname '*.TcGVL' -or -iname '*.TcPOU' \) -print0)
 
         echo "Exiting with $EXIT_CODE." >/dev/stderr
         exit $EXIT_CODE

--- a/.github/workflows/twincat-pragmalint.yml
+++ b/.github/workflows/twincat-pragmalint.yml
@@ -94,6 +94,12 @@ jobs:
           echo ""
         ) | tee -a "$GITHUB_STEP_SUMMARY"
 
+        find_source_code_files() {
+          find "${{ inputs.project-root }}" -type f -iname '*.TcDUT' -print0
+          find "${{ inputs.project-root }}" -type f -iname '*.TcGVL' -print0
+          find "${{ inputs.project-root }}" -type f -iname '*.TcPOU' -print0
+        }
+
         while IFS= read -r -d '' source_filename; do
           # Show details in the GitHub Actions output
           echo "Checking ${source_filename}"
@@ -109,7 +115,7 @@ jobs:
             echo "Pragma lint failed. Setting error code." >/dev/stderr
             EXIT_CODE=1
           fi
-        done < <(find "${{ inputs.project-root }}" -type f -iname '*.TcDUT' -or -iname '*.TcGVL' -or -iname '*.TcPOU' -print0)
+        done < <(find_source_code_files)
 
         echo "Exiting with $EXIT_CODE." >/dev/stderr
         exit $EXIT_CODE


### PR DESCRIPTION
* plc-tmo-vac is skipping over files for some bizarre reason: https://github.com/pcdshub/lcls-plc-tmo-vac/actions/runs/4429313692/jobs/7769595993
* I can reproduce this locally with just a simple bash script on the tmo project:

```bash
#!/bin/bash

while IFS= read -r -d '' source_filename; do
    echo "Checking ${source_filename}"
done < <(find "." -type f -iname '*.TcDUT' -or -iname '*.TcGVL' -or -iname '*.TcPOU' -print0)
```

```
$ find . -name "*.Tc*" |wc -l
33
(^ this includes 3 TcTTO files we don't care about so our target is 30 files)
$ bash reproducing_gha.sh  |wc -l
19
$ bash pr.sh | wc -l
30
```

(If someone can clue me in what I'm doing wrong there - I'd certainly appreciate it...)
In the meantime, the workaround in this PR seems to be fine as in the above file count listing.