### PR TITLE
FIX: inherit secrets for pip/conda jobs

### DIFF
--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -73,6 +73,7 @@ jobs:
 
     name: "Conda"
     uses: ./.github/workflows/python-conda-test.yml
+    secrets: inherit
     with:
       package-name: ${{ inputs.package-name }}
       python-version: ${{ matrix.python-version }}
@@ -95,6 +96,7 @@ jobs:
 
     name: "Pip"
     uses: ./.github/workflows/python-pip-test.yml
+    secrets: inherit
     with:
       package-name: ${{ inputs.package-name }}
       python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Continuing on with the guesswork, it seems likely that we'll need an 'inherit secrets' setting for each of our pip/conda matrices.

Ideally, it'd only inherit secrets for the 3.9 release job - but let's keep this simpler for now.

Ref: https://github.com/pcdshub/whatrecord/pull/157