### PR TITLE
MNT: check pypi token and use twine verbose mode

### DIFF
--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -224,4 +224,4 @@ jobs:
            echo "# No PYPI_TOKEN secret in job!" | tee -a "$GITHUB_STEP_SUMMARY"
            exit 1
         fi
-        twine upload dist/*
+        twine upload --verbose dist/*

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -219,4 +219,9 @@ jobs:
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      run: twine upload dist/*
+      run: |
+        if [ -z "$TWINE_PASSWORD" ]; then
+           echo "# No PYPI_TOKEN secret in job!" | tee -a "$GITHUB_STEP_SUMMARY"
+           exit 1
+        fi
+        twine upload dist/*


### PR DESCRIPTION
* Warn if TWINE_PASSWORD unset
* Use verbose mode for `twine upload`