### PR TITLE
FIX: quoted glob is a literal asterisk

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -236,7 +236,7 @@ jobs:
       run: |
         micromamba create --name upload anaconda-client
         micromamba activate upload
-        anaconda upload $HOME/conda-bld/noarch/*.tar.bz2
+        anaconda upload "${HOME}"/conda-bld/noarch/*.tar.bz2
 
     - name: pcds-tag deployment
       if: inputs.deploy-on-success && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
@@ -245,7 +245,7 @@ jobs:
       run: |
         micromamba create --name upload anaconda-client
         micromamba activate upload
-        anaconda upload $HOME/conda-bld/noarch/*.tar.bz2
+        anaconda upload "${HOME}"/conda-bld/noarch/*.tar.bz2
 
     - name: After failure
       if: ${{ failure() }}

--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -236,7 +236,7 @@ jobs:
       run: |
         micromamba create --name upload anaconda-client
         micromamba activate upload
-        anaconda upload "$HOME/conda-bld/noarch/*.tar.bz2"
+        anaconda upload $HOME/conda-bld/noarch/*.tar.bz2
 
     - name: pcds-tag deployment
       if: inputs.deploy-on-success && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
@@ -245,7 +245,7 @@ jobs:
       run: |
         micromamba create --name upload anaconda-client
         micromamba activate upload
-        anaconda upload "$HOME/conda-bld/noarch/*.tar.bz2"
+        anaconda upload $HOME/conda-bld/noarch/*.tar.bz2
 
     - name: After failure
       if: ${{ failure() }}


### PR DESCRIPTION
Unquote the glob

ref https://github.com/pcdshub/happi/actions/runs/4642229322/jobs/8245410768
```
Error:  File "/home/runner/conda-bld/noarch/*.tar.bz2" does not exist
```
Locally:
```
zlentz@psbuild-rhel7-03:~$ cat "*.py"
cat: *.py: No such file or directory
zlentz@psbuild-rhel7-03:~$ cat *.py
from pydm import Display
from pydm.widgets.label import PyDMLabel
from qtpy.QtCore import QTimer
from qtpy.QtWidgets import QVBoxLayout
```
just bash things