### PR TITLE
MNT: maybe fix empty source file check

### DIFF
--- a/.github/workflows/twincat-style.yml
+++ b/.github/workflows/twincat-style.yml
@@ -84,7 +84,9 @@ jobs:
           cat "$HOME/project_files.txt" \
             | egrep --null-data --null --ignore-case -e $"\.TcPOU$" -e $"\.TcDUT$" -e $"\.TcGVL$" \
             | egrep --null-data --null --invert-match -e "${STYLE_EXCLUDE:=__unset__}" \
-            > "$HOME/files_to_check.txt"
+            > "$HOME/files_to_check.txt" || (
+            echo "No source code files found to check."
+          )
 
     - name: Configure the matcher to annotate the diff
       run: |
@@ -112,7 +114,6 @@ jobs:
 
     - name: List the project files
       run: |
-        cat $HOME/files.sh
         echo "Project files are as follows:"
         echo "-----------------------------"
         cat "$HOME/files_to_check.txt" | xargs -0 -n1 echo

--- a/.github/workflows/twincat-syntax.yml
+++ b/.github/workflows/twincat-syntax.yml
@@ -86,7 +86,9 @@ jobs:
           cat "$HOME/project_files.txt" \
             | egrep --null-data --null --ignore-case -e $"\.TcPOU$" -e $"\.TcDUT$" -e $"\.TcGVL$" \
             | egrep --null-data --null --invert-match -e "${PARSE_EXCLUDE:=__unset__}" \
-            > "$HOME/files_to_check.txt"
+            > "$HOME/files_to_check.txt" || (
+            echo "No source code files found to check."
+          )
 
     - name: Parse changed source code
       run: |


### PR DESCRIPTION
_If you needed more evidence I have no idea what I'm doing, here's another PR for you._

This might be enough to get non-code PRs to stop bailing early on GitHub Actions.
Example: https://github.com/pcdshub/lcls-plc-rixs-optics/actions/runs/4694495047/jobs/8322692880