### PR TITLE
BLD: Fix dev deployment step conditional

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -230,7 +230,7 @@ jobs:
           2>&1 | tee "$HOME/logs/pytest_log.txt"
 
     - name: pcds-dev deployment
-      if: inputs.deploy-on-success && github.event.pull_request.merged == true && github.ref == 'refs/heads/master'
+      if: inputs.deploy-on-success && github.event_name == 'push' && github.ref == 'refs/heads/master'
       env:
         ANACONDA_API_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN_DEV }}
       run: |


### PR DESCRIPTION
Properly trigger pcds-dev deployment in conda tests.  

`github.event.pull_request` doesn't seem to exist for merge commits, so filtering for `push` events to the master branch is used as a proxy.  This should be relatively bulletproof, since we don't permit direct pushes to master... right?

This matches the pattern seen in the [pip tests (pypi deployment)](https://github.com/pcdshub/pcds-ci-helpers/blob/05492d57be61fa089fa7ef97056c630c114aee2c/.github/workflows/python-pip-test.yml#L218) and [pcds-tag deployment](https://github.com/pcdshub/pcds-ci-helpers/blob/05492d57be61fa089fa7ef97056c630c114aee2c/.github/workflows/python-conda-test.yml#L242)