### PR TITLE
FIX: correct order for diff-tree

### DIFF
--- a/.github/workflows/twincat-style.yml
+++ b/.github/workflows/twincat-style.yml
@@ -62,7 +62,7 @@ jobs:
         # * To the base that we're merging into (e.g., origin/master)
         # Note that ACMRT = added/copied/modified/renamed/type change
         # See more in `man git-diff-tree` under `--diff-filter`
-        git diff-tree --no-commit-id --name-only --diff-filter=ACM -r -z HEAD origin/${{ github.base_ref }} \
+        git diff-tree --no-commit-id --name-only --diff-filter=ACM -r -z origin/${{ github.base_ref }} HEAD \
           | tee "$HOME/project_files.txt"
 
         if [ ! -s "$HOME/project_files.txt" ]; then

--- a/.github/workflows/twincat-syntax.yml
+++ b/.github/workflows/twincat-syntax.yml
@@ -64,7 +64,7 @@ jobs:
         # * To the base that we're merging into (e.g., origin/master)
         # Note that ACMRT = added/copied/modified/renamed/type change
         # See more in `man git-diff-tree` under `--diff-filter`
-        git diff-tree --no-commit-id --name-only --diff-filter=ACM -r -z HEAD origin/${{ github.base_ref }} \
+        git diff-tree --no-commit-id --name-only --diff-filter=ACM -r -z origin/${{ github.base_ref }} HEAD \
           | tee "$HOME/project_files.txt"
 
         if [ ! -s "$HOME/project_files.txt" ]; then


### PR DESCRIPTION
Closes #123 (unless I did something else dumb)

Our goal with the `diff-tree` stuff is to see the files that changed, then only run the experimental syntax check on them because it's a slow process.

The existing implementation is broken when files are moved, causing CI to fail PR jobs.

The fix is that `diff-tree` arguments were erroneously swapped, showing the effect of reversing the merge (PR state back to master) instead of applying the merge (master to PR state).

Existing ordering (showing the bug - as `GVL_Motion.TcGVL` was removed in that linked PR):
```
lcls-plc-dream-motion$ git diff-tree --diff-filter=ACM -r HEAD  master --name-only |grep GVL
lcls-plc-dream-motion/lcls_dream_motion/GVLs/GVL_Motion.TcGVL
```

Correct (as in this PR):
```
lcls-plc-dream-motion$ git diff-tree --diff-filter=ACM -r master HEAD --name-only |grep GVL
lcls-plc-dream-motion/lcls_dream_motion/GVLs/Main.TcGVL
```

