### PR TITLE
REF: pip-based testing/docs - use pyproject-specified extras

### DIFF
--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -48,7 +48,7 @@ on:
         default: false
         type: boolean
       docs-extras:
-        default: "docs-versions-menu packaging==21.3"
+        default: ""
         description: "Extra packages to be installed for documentation"
         required: false
         type: string

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -53,7 +53,7 @@ on:
         required: false
         type: string
       requirements-files:
-        default: "dev-requirements.txt docs-requirements.txt"
+        default: ""
         description: "Development requirements filenames"
         required: false
         type: string

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -52,11 +52,6 @@ on:
         description: "Extra packages to be installed for documentation"
         required: false
         type: string
-      requirements-files:
-        default: ""
-        description: "Development requirements filenames"
-        required: false
-        type: string
       system-packages:
         default: ""
         description: "CI-specific system packages required for docs building"
@@ -190,21 +185,6 @@ jobs:
           echo "No extras to install."
         fi
 
-    - name: Installing requirements from files
-      run: |
-        for filename in ${{ inputs.requirements-files }}; do
-          if [[ ! -f "${filename}" && ! -f "${{ inputs.docs-directory }}/${filename}" ]]; then
-            echo "::warning::Requirements file not found: ${filename}"
-          else
-            if [[ -f "${filename}" ]]; then
-              pip install --requirement "${filename}"
-            fi
-            if [[ -f "${{ inputs.docs-directory }}/${filename}" ]]; then
-              pip install --requirement "${{ inputs.docs-directory }}/${filename}"
-            fi
-          fi
-        done
-
     - name: Check the pip packages in the test env
       run: |
         pip list
@@ -289,14 +269,6 @@ jobs:
         else
           echo "No extras to install."
         fi
-
-    - name: Installing requirements from files
-      run: |
-        for filename in ${{ inputs.requirements-files }}; do
-          if [[ -f "${filename}" ]]; then
-              pip install --requirement "${filename}"
-          fi
-        done
 
     - name: Download documentation artifact
       uses: actions/download-artifact@v3

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -161,7 +161,7 @@ jobs:
     - name: Installing package
       if: ${{ inputs.install-package }}
       run: |
-        pip install .
+        pip install .[test,doc]
 
     - name: Installing documentation extras
       run: |

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -27,13 +27,8 @@ on:
         required: false
         type: string
       ci-extras:
-        default: "pytest-cov"
+        default: ""
         description: "CI-specific packages to be installed"
-        required: false
-        type: string
-      requirements-file:
-        default: "dev-requirements.txt"
-        description: "Development requirements filename"
         required: false
         type: string
       system-packages:
@@ -159,7 +154,6 @@ jobs:
     - name: Run tests
       run: |
         pytest -v \
-          --cov=. \
           --log-file="$HOME/logs/debug_log.txt" \
           --log-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s' \
           --log-file-date-format='%H:%M:%S' \

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -142,22 +142,14 @@ jobs:
           test_requirements+=( "$req" )
         done
 
+        set -x
         if [[ ${#test_requirements[@]} -gt 0 ]]; then
           echo "CI extras: ${{ inputs.ci-extras }}"
           echo "Testing extras: ${{ inputs.testing-extras }}"
-          set -x
-          pip install "${test_requirements[@]}"
+          pip install "${test_requirements[@]}" .[test]
         else
           echo "No extras to install."
-        fi
-
-    - name: Installing development requirements
-      run: |
-        if [ -n "${{ inputs.requirements-file }}" ]; then
-          echo "Requirements file: ${{ inputs.requirements-file }}"
-          pip install --requirement "${{ inputs.requirements-file }}"
-        else
-          echo "No requirements file configured."
+          pip install .[test]
         fi
 
     - name: Check the pip packages in the test env

--- a/.github/workflows/twincat-standard.yml
+++ b/.github/workflows/twincat-standard.yml
@@ -60,4 +60,3 @@ jobs:
       install-package: false
       docs-template-repo: "pcdshub/twincat-docs-template"
       docs-template-ref: "master"
-      requirements-files: "requirements.txt"


### PR DESCRIPTION
* Use `pip`-provided extras for testing and documentation building
* Remove support for installing deps from text files
* Remove default CI extras for installation