### PR TITLE
MAINT: setuptools_scm breaks API intentionally and silently at v8.0.0

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -153,7 +153,7 @@ jobs:
     - name: Configure setuptools-scm
       if: ${{ inputs.use-setuptools-scm }}
       run: |
-        micromamba install setuptools-scm
+        micromamba install setuptools-scm<8.0.0
         python -m setuptools_scm
 
     - name: Build the conda package and create the test environment


### PR DESCRIPTION
Pin back to pre-v8 and wait and see if there's ever a version with backwards compatibility

We would prefer if `write_to` returns, as an existing option, even if deprecated so that we can have a transition period, but it would not be enough- we also need a non-deprecated built-in way in setuptools_scm to write out the file ourselves prior to the conda build. Otherwise, another approach would be to update all of our tomls and write out a _version file ourselves via importing the internals, which seems fragile.