### PR TITLE
FIX: upload using python 3.11 to avoid a 3.12 compatibility issue

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -239,7 +239,7 @@ jobs:
       env:
         ANACONDA_API_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN_DEV }}
       run: |
-        micromamba create --name upload anaconda-client
+        micromamba create --name upload python=3.11 anaconda-client
         micromamba activate upload
         anaconda upload "${HOME}"/conda-bld/noarch/*.tar.bz2
 
@@ -248,7 +248,7 @@ jobs:
       env:
         ANACONDA_API_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN_TAG }}
       run: |
-        micromamba create --name upload anaconda-client
+        micromamba create --name upload python=3.11 anaconda-client
         micromamba activate upload
         anaconda upload "${HOME}"/conda-bld/noarch/*.tar.bz2
 


### PR DESCRIPTION
imp was removed in python 3.12
```
    micromamba run -n upload mycommand

Traceback (most recent call last):
  File "/home/runner/micromamba/envs/upload/bin/anaconda", line 6, in <module>
    from binstar_client.scripts.cli import main
  File "/home/runner/micromamba/envs/upload/lib/python3.12/site-packages/binstar_client/__init__.py", line 19, in <module>
    from . import errors
  File "/home/runner/micromamba/envs/upload/lib/python3.12/site-packages/binstar_client/errors.py", line 3, in <module>
    from clyent.errors import ClyentError
  File "/home/runner/micromamba/envs/upload/lib/python3.12/site-packages/clyent/__init__.py", line 5, in <module>
    import imp
ModuleNotFoundError: No module named 'imp'
```