### PR TITLE
FIX: use micromamba instead of previously implicit mamba

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -215,13 +215,13 @@ jobs:
           echo "Testing extras: ${{ inputs.testing-extras }}"
           echo "In summary: ${test_requirements[@]}"
           set -x
-          mamba install "${test_requirements[@]}"
+          micromamba install "${test_requirements[@]}"
         fi
 
         if [ -n "${{ inputs.requirements-file }}" ]; then
           echo "Installing from requirements file: ${{ inputs.requirements-file }}"
           set -x
-          mamba install --file="${{ inputs.requirements-file }}"
+          micromamba install --file="${{ inputs.requirements-file }}"
         fi
 
     - name: Run tests


### PR DESCRIPTION
Previously, `boa` depended on the `mamba` package which at present largely just includes a cli for the mamba solver under the `mamba` entrypoint. (this is my limited understanding, please don't get mad at me random github comment browser)

Now, `boa` doesn't depend on this wrapper, so `mamba` doesn't get installed and these two commands fail. I don't think we actually ever needed to use this entrypoint specifically, the rest of this file uses the `micromamba` entrypoint with no issues.

This hasn't been tested but the builds are pretty broken right now without a fix.