### PR TITLE
BLD/TST: enable tmate debugging on manual workflow dispatch

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -52,6 +52,13 @@ on:
         required: false
         type: string
     outputs: {}
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled'
+        required: false
+        default: false
 
 env:
   MPLBACKEND: "agg"
@@ -77,6 +84,7 @@ jobs:
     name: "Python ${{ inputs.python-version }}: conda"
     runs-on: ubuntu-20.04
     continue-on-error: ${{ inputs.experimental }}
+    permissions: read-all
 
     defaults:
       run:
@@ -283,3 +291,10 @@ jobs:
       with:
         name: Python ${{ inputs.python-version }} - conda - testing log
         path: "~/logs"
+
+    - name: Setup tmate debugging session
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
+  

--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -297,4 +297,3 @@ jobs:
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true
-  

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -222,8 +222,7 @@ jobs:
         twine upload --verbose dist/*
 
     - name: Setup tmate debugging session
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure()}}
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true
-  

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -37,6 +37,13 @@ on:
         required: false
         type: string
     outputs: {}
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled'
+        required: false
+        default: false
 
 env:
   MPLBACKEND: "agg"
@@ -47,6 +54,7 @@ jobs:
     name: "Python ${{ inputs.python-version }}: pip"
     runs-on: ubuntu-20.04
     continue-on-error: ${{ inputs.experimental }}
+    permissions: read-all
 
     defaults:
       run:
@@ -212,3 +220,10 @@ jobs:
            exit 1
         fi
         twine upload --verbose dist/*
+
+    - name: Setup tmate debugging session
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure()}}
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
+  


### PR DESCRIPTION
## Description
Add tmate debugging to the standard python and conda workflows.

## Context
in our never ending quest to find a way to debug our ci jobs, I stumbled across this tmate action.  This allows us to directly access the runner machine, preventing us from trying and failing to build docker containers on our own.  

### How this works
The new step is only activated on a manual workflow dispatch.  Once this workflow definition is in the main/master branch, you can go to the actions tab, pick the workflow, and run a job with a `workflow_dispatch` trigger.  Forks will run this on their own account (not using our github minutes!), or we can run this on our own pcdshub branches

(The below screenshot is a fork of tangkong/gha_test)
![Screenshot 2023-12-08 at 12 02 41 PM](https://github.com/pcdshub/pcds-ci-helpers/assets/35379409/d25b1e5f-5778-4bd4-8fa1-ae60c5b9e2dc)

### Security concerns
Getting direct access to the runner is a significant security risk.  There are a couple of mitigations here, but my evaluation is still ongoing
- the debugging session requires the ssh key of the "actor" (user who triggered the workflow).  If the actor does not have an ssh key on their account the debug step fails
- I set workflow-wide GITHUB_TOKEN permissions to `read-all` (read-only).
  - the job doesn't write to github at all, so this shouldn't change anything
  - we also don't use the token in this workflow anyway
- Secrets only exist as environment variables in the step they were assigned (I checked this, but there's probably documentation somewhere)
- We should figure out how to lock down the Conda / PyPI tokens?
  - Those secrets are only accessed in their respective steps, so it should be ok