### PR TITLE
MAINT: update to checkout v4 to avoid deprecation warning from v3

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Configure the matcher to annotate the diff
       if: ${{ inputs.annotate }}

--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -96,7 +96,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: 'recursive'

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -82,12 +82,12 @@ jobs:
       deploy_version: ${{ steps.version.outputs.built_docs_version }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: 'recursive'
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: inputs.docs-template-repo != ''
       with:
         repository: ${{ inputs.docs-template-repo }}

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -66,7 +66,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: 'recursive'

--- a/.github/workflows/twincat-pragmalint.yml
+++ b/.github/workflows/twincat-pragmalint.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash --login -o pipefail {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: 'recursive'

--- a/.github/workflows/twincat-style.yml
+++ b/.github/workflows/twincat-style.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash --login -o pipefail {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: 'recursive'

--- a/.github/workflows/twincat-summary.yml
+++ b/.github/workflows/twincat-summary.yml
@@ -34,7 +34,7 @@ jobs:
         shell: bash --login -o pipefail {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: 'recursive'

--- a/.github/workflows/twincat-syntax.yml
+++ b/.github/workflows/twincat-syntax.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash --login -o pipefail {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: 'recursive'


### PR DESCRIPTION
Today I noticed some deprecation warnings in pcds-envs, which also needs a PR:
![image](https://github.com/pcdshub/pcds-ci-helpers/assets/10647860/442da6b7-f74b-4405-b326-592f2caec3c0)

I did a find and replace for checkout@v3 -> checkout@v4
v4 was released back in October