### PR TITLE
MNT: update setup-python and artifact actions for NodeJS compatibility

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -181,7 +181,7 @@ jobs:
           2>&1 | tee $HOME/logs/mambabuild.txt
 
     - name: Upload the built package as an artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Python ${{ inputs.python-version }} - conda - package
         path: ~/conda-bld
@@ -287,7 +287,7 @@ jobs:
         cat "$HOME/logs/debug_log.txt" || echo "Debug logfile not found?"
 
     - name: Upload log file artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Python ${{ inputs.python-version }} - conda - testing log
         path: "~/logs"

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -196,14 +196,14 @@ jobs:
         make html 2>&1 | tee $HOME/logs/docs-build.txt
 
     - name: Upload documentation as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Python ${{ inputs.python-version }} - documentation
         path: "${{ inputs.docs-directory }}/${{ inputs.docs-build-directory }}"
 
     - name: Upload log file artifacts
       if: ${{ always() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Python ${{ inputs.python-version }} - documentation - logs
         path: "~/logs"
@@ -250,7 +250,7 @@ jobs:
         pip install docs-versions-menu
 
     - name: Download documentation artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Python ${{ inputs.python-version }} - documentation
 

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -146,7 +146,7 @@ jobs:
       run: |
         mkdir $HOME/logs
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '${{ inputs.python-version }}'
 
@@ -237,7 +237,7 @@ jobs:
       # url: ${{ steps.build-and-deploy.outputs.page_url }}
 
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '${{ inputs.python-version }}'
 

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -197,14 +197,14 @@ jobs:
 
     - name: Upload log file artifacts
       if: ${{ always() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Python ${{ inputs.python-version }} - pip - testing log
         path: "~/logs"
 
     - name: Upload the package as an artifact
       if: ${{ always() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Python ${{ inputs.python-version }} - pip - package
         path: dist

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -95,7 +95,7 @@ jobs:
       run: |
         mkdir $HOME/logs
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '${{ inputs.python-version }}'
 

--- a/.github/workflows/twincat-pragmalint.yml
+++ b/.github/workflows/twincat-pragmalint.yml
@@ -44,7 +44,7 @@ jobs:
         fetch-depth: 0
         submodules: 'recursive'
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '${{ inputs.python-version }}'
 

--- a/.github/workflows/twincat-summary.yml
+++ b/.github/workflows/twincat-summary.yml
@@ -39,7 +39,7 @@ jobs:
         fetch-depth: 0
         submodules: 'recursive'
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '${{ inputs.python-version }}'
 

--- a/.github/workflows/twincat-syntax.yml
+++ b/.github/workflows/twincat-syntax.yml
@@ -44,7 +44,7 @@ jobs:
         fetch-depth: 0
         submodules: 'recursive'
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '${{ inputs.python-version }}'
 


### PR DESCRIPTION
closes #141

I suppose there's no tests for the tests, but I think this should work ok.  We don't actually download any artifacts except for the documentation artifact, and the artifacts are all named differently anyway.  