### PR TITLE
BLD: add python 3.12 to the test matrix

### DIFF
--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -70,6 +70,8 @@ jobs:
         - python-version: "3.10"
         - python-version: "3.11"
           experimental: true
+        - python-version: "3.12"
+          experimental: true
 
     name: "Conda"
     uses: ./.github/workflows/python-conda-test.yml
@@ -92,6 +94,8 @@ jobs:
           deploy-on-success: true
         - python-version: "3.10"
         - python-version: "3.11"
+          experimental: true
+        - python-version: "3.12"
           experimental: true
 
     name: "Pip"


### PR DESCRIPTION
This should only be merged when we get 3.12 fully working, otherwise we'll just get a bunch of ❌ 