### PR TITLE
MAINT: python 3.12 builds are not getting past conda-verify step

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -146,7 +146,12 @@ jobs:
 
     - name: Install boa for mambabuild
       run: |
-        micromamba install boa conda-verify "python=${{ inputs.python-version }}"
+        # conda-verify has not been released on conda-forge since 2019 and has no py3.12 build
+        if [ "${{ inputs.python-version }}" == "3.12" ]; then
+          micromamba install boa "python=${{ inputs.python-version }}"
+        else
+          micromamba install boa conda-verify "python=${{ inputs.python-version }}"
+        fi
         micromamba info
 
     - name: Check condarc


### PR DESCRIPTION
So, why not skip it?

```
$ mamba create --name verifytest python=3.12 conda-verify

Looking for: ['python=3.12', 'conda-verify']

pcds-tag/noarch                                               No change
pcds-tag/linux-64                                             No change
conda-forge/noarch                                  14.6MB @  29.5MB/s  1.3s
conda-forge/linux-64                                34.4MB @  21.7MB/s  3.8s
Could not solve for environment specs
The following packages are incompatible
├─ conda-verify is installable with the potential options
│  ├─ conda-verify [2.0.0|3.1.1] would require
│  │  └─ python [2.7* |>=2.7,<2.8.0a0 ], which can be installed;
│  ├─ conda-verify [2.0.0|3.1.1] would require
│  │  └─ python [3.5* |>=3.5,<3.6.0a0 ], which can be installed;
│  ├─ conda-verify 2.0.0 would require
│  │  └─ python 3.6* , which can be installed;
│  ├─ conda-verify 3.1.1 would require
│  │  └─ python_abi 3.10.* *_cp310, which can be installed;
│  ├─ conda-verify 3.1.1 would require
│  │  └─ python_abi 3.11.* *_cp311, which can be installed;
│  ├─ conda-verify 3.1.1 would require
│  │  └─ python >=3.6,<3.7.0a0 , which can be installed;
│  ├─ conda-verify 3.1.1 would require
│  │  └─ python_abi 3.6.* *_cp36m, which can be installed;
│  ├─ conda-verify 3.1.1 would require
│  │  └─ python_abi 3.6 *_pypy36_pp73, which can be installed;
│  ├─ conda-verify 3.1.1 would require
│  │  └─ python >=3.7,<3.8.0a0 , which can be installed;
│  ├─ conda-verify 3.1.1 would require
│  │  └─ python_abi 3.7.* *_cp37m, which can be installed;
│  ├─ conda-verify 3.1.1 would require
│  │  └─ python_abi 3.7 *_pypy37_pp73, which can be installed;
│  ├─ conda-verify 3.1.1 would require
│  │  └─ python >=3.8,<3.9.0a0 , which can be installed;
│  ├─ conda-verify 3.1.1 would require
│  │  └─ python_abi 3.8.* *_cp38, which can be installed;
│  ├─ conda-verify 3.1.1 would require
│  │  └─ python_abi 3.8 *_pypy38_pp73, which can be installed;
│  ├─ conda-verify 3.1.1 would require
│  │  └─ python_abi 3.9 *_pypy39_pp73, which can be installed;
│  └─ conda-verify 3.1.1 would require
│     └─ python_abi 3.9.* *_cp39, which can be installed;
└─ python 3.12**  is not installable because there are no viable options
   ├─ python [3.12.0|3.12.1|3.12.2|3.12.3] would require
   │  └─ python_abi 3.12.* *_cp312, which conflicts with any installable versions previously reported;
   └─ python 3.12.0rc3 would require
      └─ _python_rc, which does not exist (perhaps a missing channel).
```