### PR TITLE
CI: remove read-all permissions specification, non-operational tmate debugging

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -84,7 +84,6 @@ jobs:
     name: "Python ${{ inputs.python-version }}: conda"
     runs-on: ubuntu-20.04
     continue-on-error: ${{ inputs.experimental }}
-    permissions: read-all
 
     defaults:
       run:
@@ -296,9 +295,3 @@ jobs:
       with:
         name: Python ${{ inputs.python-version }} - conda - testing log
         path: "~/logs"
-
-    - name: Setup tmate debugging session
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -54,7 +54,6 @@ jobs:
     name: "Python ${{ inputs.python-version }}: pip"
     runs-on: ubuntu-20.04
     continue-on-error: ${{ inputs.experimental }}
-    permissions: read-all
 
     defaults:
       run:
@@ -220,9 +219,3 @@ jobs:
            exit 1
         fi
         twine upload --verbose dist/*
-
-    - name: Setup tmate debugging session
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true


### PR DESCRIPTION
We ran into some issues where GHE runners didn't like the read-all permissions, instead only allowing "all".

Also tmate debugging never managed to work, I can loop back to it later