### PR TITLE
BLD: reenable documentation builds, remove leftover tmate bits

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -52,13 +52,6 @@ on:
         required: false
         type: string
     outputs: {}
-  workflow_dispatch:
-    inputs:
-      debug_enabled:
-        type: boolean
-        description: 'Run the build with tmate debugging enabled'
-        required: false
-        default: false
 
 env:
   MPLBACKEND: "agg"

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -37,13 +37,6 @@ on:
         required: false
         type: string
     outputs: {}
-  workflow_dispatch:
-    inputs:
-      debug_enabled:
-        type: boolean
-        description: 'Run the build with tmate debugging enabled'
-        required: false
-        default: false
 
 env:
   MPLBACKEND: "agg"

--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -109,11 +109,11 @@ jobs:
       system-packages: ${{ inputs.pip-system-packages }}
       testing-extras: ${{ inputs.testing-extras }} ${{ inputs.pip-testing-extras }}
 
-  # pip-docs:
-  #   name: "Documentation"
-  #   uses: ./.github/workflows/python-docs.yml
-  #   with:
-  #     package-name: ${{ inputs.package-name }}
-  #     python-version: ${{ inputs.python-version-docs }}
-  #     deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
-  #     system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}
+  pip-docs:
+    name: "Documentation"
+    uses: ./.github/workflows/python-docs.yml
+    with:
+      package-name: ${{ inputs.package-name }}
+      python-version: ${{ inputs.python-version-docs }}
+      deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
+      system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}

--- a/.github/workflows/twincat-standard.yml
+++ b/.github/workflows/twincat-standard.yml
@@ -51,12 +51,12 @@ jobs:
     with:
       project-root: ${{ inputs.project-root }}
 
-  # docs:
-  #   name: "Documentation"
-  #   uses: ./.github/workflows/python-docs.yml
-  #   with:
-  #     deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
-  #     package-name: ""
-  #     install-package: false
-  #     docs-template-repo: "pcdshub/twincat-docs-template"
-  #     docs-template-ref: "master"
+  docs:
+    name: "Documentation"
+    uses: ./.github/workflows/python-docs.yml
+    with:
+      deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
+      package-name: ""
+      install-package: false
+      docs-template-repo: "pcdshub/twincat-docs-template"
+      docs-template-ref: "master"


### PR DESCRIPTION
Reverting changes from #147, now that GHE has fixed our permissions