### PR TITLE
MNT: turn off conda tests in pip_only branch

### DIFF
--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -60,30 +60,30 @@ jobs:
     with:
       args: "--all-files"
 
-  conda-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - python-version: "3.9"
-          deploy-on-success: true
-        - python-version: "3.10"
-        - python-version: "3.11"
-          experimental: true
-        - python-version: "3.12"
-          experimental: true
+  # conda-test:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #       - python-version: "3.9"
+  #         deploy-on-success: true
+  #       - python-version: "3.10"
+  #       - python-version: "3.11"
+  #         experimental: true
+  #       - python-version: "3.12"
+  #         experimental: true
 
-    name: "Conda"
-    uses: ./.github/workflows/python-conda-test.yml
-    secrets: inherit
-    with:
-      package-name: ${{ inputs.package-name }}
-      python-version: ${{ matrix.python-version }}
-      experimental: ${{ matrix.experimental || false }}
-      deploy-on-success: ${{ matrix.deploy-on-success || false }}
-      testing-extras: ${{ inputs.testing-extras }} ${{ inputs.conda-testing-extras }}
-      system-packages: ${{ inputs.conda-system-packages }}
-      use-setuptools-scm: ${{ inputs.use-setuptools-scm }}
+    # name: "Conda"
+    # uses: ./.github/workflows/python-conda-test.yml
+    # secrets: inherit
+    # with:
+    #   package-name: ${{ inputs.package-name }}
+    #   python-version: ${{ matrix.python-version }}
+    #   experimental: ${{ matrix.experimental || false }}
+    #   deploy-on-success: ${{ matrix.deploy-on-success || false }}
+    #   testing-extras: ${{ inputs.testing-extras }} ${{ inputs.conda-testing-extras }}
+    #   system-packages: ${{ inputs.conda-system-packages }}
+    #   use-setuptools-scm: ${{ inputs.use-setuptools-scm }}
 
   pip-test:
     strategy:


### PR DESCRIPTION
An experimental branch, we can choose not to go this route if we like.  I mostly want to stop filtering red ❌ on the BEAMS repo

Note: I'm requesting this branch be merged into the `pcdshub:pip_only` branch, not `master`