### PR TITLE
FIX: update pre-commit image to current ubuntu latest

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The ubuntu-20.04 image runs python 3.8 which is too old for some of the twincat pre-commit builds.

Rather than keep using the old image, I opted to update to the 22.04 image that is currently tagged as "ubuntu-latest".
I could have also chosen 24.04 but since it wasn't tagged as latest I decided to only go up to 22.04.

List of builds:
https://github.com/actions/runner-images/tree/main

I then tried to run pre-commit on CI on a repo that was previously failing.
Failing build: https://github.com/pcdshub/lcls-twincat-math/actions/runs/11582459856/job/32245532359
My passing build: https://github.com/ZLLentz/lcls-twincat-math/actions/runs/11710367753/job/32616497674

I did not try this again on the python repos but I expect this to be transparent.
I am not currently interested in updating _all_ the builds because that has some (low) risk of creating havoc and I'm not ready for that today.

Ref https://jira.slac.stanford.edu/browse/ECS-6684
