### PR TITLE
MNT: update off of deprecated runner OS to latest

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -75,7 +75,7 @@ env:
 jobs:
   build-and-test:
     name: "Python ${{ inputs.python-version }}: conda"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ inputs.experimental }}
 
     defaults:

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -66,7 +66,7 @@ env:
 jobs:
   build:
     name: "Python ${{ inputs.python-version }}: documentation building"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ inputs.experimental }}
 
     defaults:

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   test:
     name: "Python ${{ inputs.python-version }}: pip"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ inputs.experimental }}
 
     defaults:

--- a/.github/workflows/twincat-pragmalint.yml
+++ b/.github/workflows/twincat-pragmalint.yml
@@ -28,7 +28,7 @@ jobs:
   style:
     name: "Pragma Linting"
     continue-on-error: true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/twincat-style.yml
+++ b/.github/workflows/twincat-style.yml
@@ -38,7 +38,7 @@ jobs:
 
     name: "${{ matrix.description }}"
     continue-on-error: ${{ matrix.fatal }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/twincat-summary.yml
+++ b/.github/workflows/twincat-summary.yml
@@ -23,7 +23,7 @@ jobs:
   style:
     name: "Project Summary"
     continue-on-error: true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/twincat-syntax.yml
+++ b/.github/workflows/twincat-syntax.yml
@@ -28,7 +28,7 @@ jobs:
   syntax:
     name: "Experimental Syntax Check"
     continue-on-error: true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:


### PR DESCRIPTION
Builds are starting to fail because of an ubuntu-20.04 brownout

ubuntu-20.04 as a runner os will be removed this month

This PR opts to switch us to always latest, which right now is ubuntu-24.04 and will automatically update when they release a new one.

It's not clear if this will give us problems in the future but we can adjust again without much pain.