### PR TITLE
BLD/DOC: update docs deployment to ubuntu-latest

### DIFF
--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -210,7 +210,7 @@ jobs:
 
   deploy:
     name: "Documentation deployment"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
     if: ${{ inputs.deploy }}
 


### PR DESCRIPTION
Somehow we missed this in the earlier update.  I thought I grepped through the repo for all the ubuntu references but I guess I missed one