### PR TITLE
MNT: Update Pip only branch to use latest ubuntu runners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# default group
+* @pcdshub/software-admin
+
+# github folder holds administrative files
+.github/** @pcdshub/software-admin

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -52,13 +52,6 @@ on:
         required: false
         type: string
     outputs: {}
-  workflow_dispatch:
-    inputs:
-      debug_enabled:
-        type: boolean
-        description: 'Run the build with tmate debugging enabled'
-        required: false
-        default: false
 
 env:
   MPLBACKEND: "agg"

--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -75,7 +75,7 @@ env:
 jobs:
   build-and-test:
     name: "Python ${{ inputs.python-version }}: conda"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ inputs.experimental }}
 
     defaults:

--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -84,7 +84,6 @@ jobs:
     name: "Python ${{ inputs.python-version }}: conda"
     runs-on: ubuntu-20.04
     continue-on-error: ${{ inputs.experimental }}
-    permissions: read-all
 
     defaults:
       run:
@@ -296,9 +295,3 @@ jobs:
       with:
         name: Python ${{ inputs.python-version }} - conda - testing log
         path: "~/logs"
-
-    - name: Setup tmate debugging session
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -210,7 +210,7 @@ jobs:
 
   deploy:
     name: "Documentation deployment"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
     if: ${{ inputs.deploy }}
 

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -66,7 +66,7 @@ env:
 jobs:
   build:
     name: "Python ${{ inputs.python-version }}: documentation building"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ inputs.experimental }}
 
     defaults:

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -54,7 +54,6 @@ jobs:
     name: "Python ${{ inputs.python-version }}: pip"
     runs-on: ubuntu-20.04
     continue-on-error: ${{ inputs.experimental }}
-    permissions: read-all
 
     defaults:
       run:
@@ -220,9 +219,3 @@ jobs:
            exit 1
         fi
         twine upload --verbose dist/*
-
-    - name: Setup tmate debugging session
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -37,13 +37,6 @@ on:
         required: false
         type: string
     outputs: {}
-  workflow_dispatch:
-    inputs:
-      debug_enabled:
-        type: boolean
-        description: 'Run the build with tmate debugging enabled'
-        required: false
-        default: false
 
 env:
   MPLBACKEND: "agg"

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   test:
     name: "Python ${{ inputs.python-version }}: pip"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ inputs.experimental }}
 
     defaults:

--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -109,11 +109,11 @@ jobs:
       system-packages: ${{ inputs.pip-system-packages }}
       testing-extras: ${{ inputs.testing-extras }} ${{ inputs.pip-testing-extras }}
 
-  pip-docs:
-    name: "Documentation"
-    uses: ./.github/workflows/python-docs.yml
-    with:
-      package-name: ${{ inputs.package-name }}
-      python-version: ${{ inputs.python-version-docs }}
-      deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
-      system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}
+  # pip-docs:
+  #   name: "Documentation"
+  #   uses: ./.github/workflows/python-docs.yml
+  #   with:
+  #     package-name: ${{ inputs.package-name }}
+  #     python-version: ${{ inputs.python-version-docs }}
+  #     deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
+  #     system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}

--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -60,30 +60,30 @@ jobs:
     with:
       args: "--all-files"
 
-  conda-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - python-version: "3.9"
-          deploy-on-success: true
-        - python-version: "3.10"
-        - python-version: "3.11"
-          experimental: true
-        - python-version: "3.12"
-          experimental: true
+  # conda-test:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #       - python-version: "3.9"
+  #         deploy-on-success: true
+  #       - python-version: "3.10"
+  #       - python-version: "3.11"
+  #         experimental: true
+  #       - python-version: "3.12"
+  #         experimental: true
 
-    name: "Conda"
-    uses: ./.github/workflows/python-conda-test.yml
-    secrets: inherit
-    with:
-      package-name: ${{ inputs.package-name }}
-      python-version: ${{ matrix.python-version }}
-      experimental: ${{ matrix.experimental || false }}
-      deploy-on-success: ${{ matrix.deploy-on-success || false }}
-      testing-extras: ${{ inputs.testing-extras }} ${{ inputs.conda-testing-extras }}
-      system-packages: ${{ inputs.conda-system-packages }}
-      use-setuptools-scm: ${{ inputs.use-setuptools-scm }}
+    # name: "Conda"
+    # uses: ./.github/workflows/python-conda-test.yml
+    # secrets: inherit
+    # with:
+    #   package-name: ${{ inputs.package-name }}
+    #   python-version: ${{ matrix.python-version }}
+    #   experimental: ${{ matrix.experimental || false }}
+    #   deploy-on-success: ${{ matrix.deploy-on-success || false }}
+    #   testing-extras: ${{ inputs.testing-extras }} ${{ inputs.conda-testing-extras }}
+    #   system-packages: ${{ inputs.conda-system-packages }}
+    #   use-setuptools-scm: ${{ inputs.use-setuptools-scm }}
 
   pip-test:
     strategy:

--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -109,11 +109,11 @@ jobs:
       system-packages: ${{ inputs.pip-system-packages }}
       testing-extras: ${{ inputs.testing-extras }} ${{ inputs.pip-testing-extras }}
 
-  # pip-docs:
-  #   name: "Documentation"
-  #   uses: ./.github/workflows/python-docs.yml
-  #   with:
-  #     package-name: ${{ inputs.package-name }}
-  #     python-version: ${{ inputs.python-version-docs }}
-  #     deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
-  #     system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}
+  pip-docs:
+    name: "Documentation"
+    uses: ./.github/workflows/python-docs.yml
+    with:
+      package-name: ${{ inputs.package-name }}
+      python-version: ${{ inputs.python-version-docs }}
+      deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
+      system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}

--- a/.github/workflows/twincat-pragmalint.yml
+++ b/.github/workflows/twincat-pragmalint.yml
@@ -28,7 +28,7 @@ jobs:
   style:
     name: "Pragma Linting"
     continue-on-error: true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/twincat-standard.yml
+++ b/.github/workflows/twincat-standard.yml
@@ -51,12 +51,12 @@ jobs:
     with:
       project-root: ${{ inputs.project-root }}
 
-  docs:
-    name: "Documentation"
-    uses: ./.github/workflows/python-docs.yml
-    with:
-      deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
-      package-name: ""
-      install-package: false
-      docs-template-repo: "pcdshub/twincat-docs-template"
-      docs-template-ref: "master"
+  # docs:
+  #   name: "Documentation"
+  #   uses: ./.github/workflows/python-docs.yml
+  #   with:
+  #     deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
+  #     package-name: ""
+  #     install-package: false
+  #     docs-template-repo: "pcdshub/twincat-docs-template"
+  #     docs-template-ref: "master"

--- a/.github/workflows/twincat-standard.yml
+++ b/.github/workflows/twincat-standard.yml
@@ -51,12 +51,12 @@ jobs:
     with:
       project-root: ${{ inputs.project-root }}
 
-  # docs:
-  #   name: "Documentation"
-  #   uses: ./.github/workflows/python-docs.yml
-  #   with:
-  #     deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
-  #     package-name: ""
-  #     install-package: false
-  #     docs-template-repo: "pcdshub/twincat-docs-template"
-  #     docs-template-ref: "master"
+  docs:
+    name: "Documentation"
+    uses: ./.github/workflows/python-docs.yml
+    with:
+      deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
+      package-name: ""
+      install-package: false
+      docs-template-repo: "pcdshub/twincat-docs-template"
+      docs-template-ref: "master"

--- a/.github/workflows/twincat-style.yml
+++ b/.github/workflows/twincat-style.yml
@@ -38,7 +38,7 @@ jobs:
 
     name: "${{ matrix.description }}"
     continue-on-error: ${{ matrix.fatal }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/twincat-summary.yml
+++ b/.github/workflows/twincat-summary.yml
@@ -23,7 +23,7 @@ jobs:
   style:
     name: "Project Summary"
     continue-on-error: true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/twincat-syntax.yml
+++ b/.github/workflows/twincat-syntax.yml
@@ -28,7 +28,7 @@ jobs:
   syntax:
     name: "Experimental Syntax Check"
     continue-on-error: true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:


### PR DESCRIPTION
Commit history is a bit squirrely here, but beams wants to only use the pip tests.  This little dev branch fell behind master.