### PR TITLE
MNT: update python test matrix to only require 3.9, 3.12.  Target 3.13, 3.14 as experimental

### DIFF
--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -91,11 +91,11 @@ jobs:
       matrix:
         include:
         - python-version: "3.9"
-          deploy-on-success: true
-        - python-version: "3.10"
-        - python-version: "3.11"
-          experimental: true
         - python-version: "3.12"
+          deploy-on-success: true
+        - python-version: "3.13"
+          experimental: true
+        - python-version: "3.14"
           experimental: true
 
     name: "Pip"


### PR DESCRIPTION
As per the title.  Now that we're rolling out a 3.12 environment, we know that we won't need testing against the versions in between. We can also start testing compatibility with newer versions of python. 

One last thing that will need to be changed is the rulesets, which currently require 3.10 builds.  

Open to discussion as to where the deploy-on-success flag goes.  I think 3.12 is appropriate, but maybe we're not entirely there yet 