### PR TITLE
MNT: update python test matrix, attempt 2

### DIFF
--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -9,7 +9,7 @@ on:
         type: string
       python-version:
         description: "The Python version to build and test with"
-        default: "3.9"
+        default: "3.12"
         required: false
         type: string
       install-package:

--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -10,7 +10,7 @@ on:
       python-version-docs:
         required: false
         type: string
-        default: "3.9"
+        default: "3.12"
         description: "Python version for docs building"
       testing-extras:
         required: false

--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -66,11 +66,9 @@ jobs:
       matrix:
         include:
         - python-version: "3.9"
-          deploy-on-success: true
-        - python-version: "3.10"
-        - python-version: "3.11"
-          experimental: true
         - python-version: "3.12"
+          deploy-on-success: true
+        - python-version: "3.13"
           experimental: true
 
     name: "Conda"
@@ -94,8 +92,6 @@ jobs:
         - python-version: "3.12"
           deploy-on-success: true
         - python-version: "3.13"
-          experimental: true
-        - python-version: "3.14"
           experimental: true
 
     name: "Pip"


### PR DESCRIPTION
- Adjusts the python test matrices to include 3.9, 3.12, and 3.13
  - 3.14 is only available in beta from github actions ([ref](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json)), and not available at all on conda.  I think it's worth keeping the symmetrical
- Updates the docs builds to use python 3.12.
  - This could have probably been done earlier.  I told myself to be more thorough and ended up targeting anything that had "3.9"