### PR TITLE
MNT: remove conda verify from conda tests, is unused and not supported for later python versions

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -138,12 +138,7 @@ jobs:
 
     - name: Install boa for mambabuild
       run: |
-        # conda-verify has not been released on conda-forge since 2019 and has no py3.12 build
-        if [ "${{ inputs.python-version }}" == "3.12" ]; then
-          micromamba install boa "python=${{ inputs.python-version }}"
-        else
-          micromamba install boa conda-verify "python=${{ inputs.python-version }}"
-        fi
+        micromamba install boa "python=${{ inputs.python-version }}"
         micromamba info
 
     - name: Check condarc


### PR DESCRIPTION
This was brought to my attention by Devan, and when I looked into it I couldn't find out where we actually run conda-verify.

I assume we've been "verifying" our recipes by  seeing if the rest of the job blows up