### PR TITLE
BLD: disable conda3.13 build

### DIFF
--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -68,8 +68,10 @@ jobs:
         - python-version: "3.9"
         - python-version: "3.12"
           deploy-on-success: true
-        - python-version: "3.13"
-          experimental: true
+        # Disabling until we support rattler-build, boa/mambabuild does not work
+        # with py3.13
+        # - python-version: "3.13"
+        #   experimental: true
 
     name: "Conda"
     uses: ./.github/workflows/python-conda-test.yml


### PR DESCRIPTION
boa and mambabuild have been deprecated in favor of `rattler-build`, which needs a dedicated migration process.  

Until we organize that, we'll need to not have this job perma-failing.

https://rattler.build/latest/reference/recipe_file/#major-differences-from-conda-build
https://conda-forge.org/blog/2025/02/27/conda-forge-v1-recipe-support/