### PR TITLE
TST: Adjustments for my pcdswidgets PR

### DIFF
--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -227,11 +227,14 @@ jobs:
 
     - name: Run tests
       run: |
+        cd $HOME
         pytest -v \
           --log-file="$HOME/logs/debug_log.txt" \
           --log-format='%(asctime)s.%(msecs)03d %(module)-15s %(levelname)-8s %(threadName)-10s %(message)s' \
           --log-file-date-format='%H:%M:%S' \
           --log-level=DEBUG \
+          --pyargs \
+          ${{ inputs.package-name }}" \
           2>&1 | tee "$HOME/logs/pytest_log.txt"
 
     - name: pcds-dev deployment

--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -234,7 +234,7 @@ jobs:
           --log-file-date-format='%H:%M:%S' \
           --log-level=DEBUG \
           --pyargs \
-          ${{ inputs.package-name }}" \
+          ${{ inputs.package-name }} \
           2>&1 | tee "$HOME/logs/pytest_log.txt"
 
     - name: pcds-dev deployment

--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -27,7 +27,7 @@ on:
         type: string
         default: ""
         description: "Extras only for pip-based testing"
-      docs-build_extras:
+      docs-build-extras:
         required: false
         type: string
         default: ""

--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -27,6 +27,11 @@ on:
         type: string
         default: ""
         description: "Extras only for pip-based testing"
+      docs-build_extras:
+        required: false
+        type: string
+        default: ""
+        description: "Extras only for docs builds (installed via pip)"
       conda-system-packages:
         required: false
         type: string
@@ -114,6 +119,7 @@ jobs:
       package-name: ${{ inputs.package-name }}
       python-version: ${{ inputs.python-version-docs }}
       deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
+      docs-extras: ${{ inputs.docs-build_extras }}
       system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}
 
   coverage:

--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -119,7 +119,7 @@ jobs:
       package-name: ${{ inputs.package-name }}
       python-version: ${{ inputs.python-version-docs }}
       deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
-      docs-extras: ${{ inputs.docs-build_extras }}
+      docs-extras: ${{ inputs.docs-build-extras }}
       system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}
 
   coverage:


### PR DESCRIPTION
This makes my `pcdswidgets` tests pass and helps the docs build properly

See https://github.com/pcdshub/pcdswidgets/pull/96

## Change 1: run conda test from installed version

- I've added a build step to `pcdswidgets`
- This builds and installs correctly
- Without this change, the conda tests run on the pre-built version of the package

Things to consider:
- This makes the test output pretty awful (`micromamba/conda-bld/pcdswidgets_1773337587302/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla/lib/python3.12/site-packages/pcdswidgets/tests/test_builder.py::test_it_was_built[ui_source0] PASSED [  1%]`)
- This ensures that we're testing on the version of the package that gets installed
- I didn't change the pypi tests because the pypi build runs and builds install-time files in the cloned repo, so the tests work for me, but maybe this should also be done on the pypi tests.

## Change 2: expose the docs extras argument

- In `pcdswidgets` I need to keep `pyqt` out of the pypi requirements for smooth local environment generation
- I then need to add it back for the pip tests and docs builds
- There is a hook for the docs builds that we hadn't been exposing, this exposes it