### PR TITLE
MNT: remove experimental syntax check from twincat-standard.yml

### DIFF
--- a/.github/workflows/twincat-standard.yml
+++ b/.github/workflows/twincat-standard.yml
@@ -49,13 +49,6 @@ jobs:
       project-root: ${{ inputs.project-root }}
       style-exclude: ${{ inputs.style-exclude }}
 
-  syntax:
-    name: "Syntax check"
-    secrets: inherit
-    uses: ./.github/workflows/twincat-syntax.yml
-    with:
-      project-root: ${{ inputs.project-root }}
-
   docs:
     name: "Documentation"
     secrets: inherit


### PR DESCRIPTION
This typically fails everywhere and isn't complete. Let's disable it by default and add it back in manually if/where we want it.