### PR TITLE
CI: add dependabot config for updating github actions references monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
In preparation for required SHA pinning, I'm going to set dependabot loose on the github actions config here.

This is both a learning ground for what can be applied to other repos and a necessary step.

I'm hoping that there's some way to leverage this to set full SHAs automatically- to start, I will create this config and then mess with the settings until I achieve this or decide that I have to set something manually.