### PR TITLE
CI: pin all actions with SHA, hope dependabot will update them

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         token: ${{ secrets.CHECKOUT_TOKEN || github.token }}
 

--- a/.github/workflows/python-conda-test.yml
+++ b/.github/workflows/python-conda-test.yml
@@ -88,7 +88,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0
         submodules: 'recursive'
@@ -174,7 +174,7 @@ jobs:
           2>&1 | tee $HOME/logs/mambabuild.txt
 
     - name: Upload the built package as an artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: Python ${{ inputs.python-version }} - conda - package
         path: ~/conda-bld
@@ -279,7 +279,7 @@ jobs:
         cat "$HOME/logs/debug_log.txt" || echo "Debug logfile not found?"
 
     - name: Upload log file artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: Python ${{ inputs.python-version }} - conda - testing log
         path: "~/logs"

--- a/.github/workflows/python-coverage-test.yml
+++ b/.github/workflows/python-coverage-test.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0
         submodules: 'recursive'
@@ -83,7 +83,7 @@ jobs:
       run: |
         mkdir $HOME/logs
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: '${{ inputs.python-version }}'
 
@@ -194,14 +194,14 @@ jobs:
 
     - name: Upload log file artifacts
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: Python ${{ inputs.python-version }} - coverage logs
         path: "~/logs"
 
     - name: Upload coverage file artifacts
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: Python ${{ inputs.python-version }} - coverage report
         path: "~/coverage_reports"

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -82,13 +82,13 @@ jobs:
       deploy_version: ${{ steps.version.outputs.built_docs_version }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0
         submodules: 'recursive'
         token: ${{ secrets.CHECKOUT_TOKEN || github.token }}
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       if: inputs.docs-template-repo != ''
       with:
         repository: ${{ inputs.docs-template-repo }}
@@ -147,7 +147,7 @@ jobs:
       run: |
         mkdir $HOME/logs
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: '${{ inputs.python-version }}'
 
@@ -197,14 +197,14 @@ jobs:
         make html 2>&1 | tee $HOME/logs/docs-build.txt
 
     - name: Upload documentation as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: Python ${{ inputs.python-version }} - documentation
         path: "${{ inputs.docs-directory }}/${{ inputs.docs-build-directory }}"
 
     - name: Upload log file artifacts
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: Python ${{ inputs.python-version }} - documentation - logs
         path: "~/logs"
@@ -238,7 +238,7 @@ jobs:
       # url: ${{ steps.build-and-deploy.outputs.page_url }}
 
     steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: '${{ inputs.python-version }}'
 
@@ -251,7 +251,7 @@ jobs:
         pip install docs-versions-menu
 
     - name: Download documentation artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: Python ${{ inputs.python-version }} - documentation
 

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0
         submodules: 'recursive'
@@ -88,7 +88,7 @@ jobs:
       run: |
         mkdir $HOME/logs
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: '${{ inputs.python-version }}'
 
@@ -190,14 +190,14 @@ jobs:
 
     - name: Upload log file artifacts
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: Python ${{ inputs.python-version }} - pip - testing log
         path: "~/logs"
 
     - name: Upload the package as an artifact
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: Python ${{ inputs.python-version }} - pip - package
         path: dist

--- a/.github/workflows/twincat-pragmalint.yml
+++ b/.github/workflows/twincat-pragmalint.yml
@@ -39,13 +39,13 @@ jobs:
         shell: bash --login -o pipefail {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0
         submodules: 'recursive'
         token: ${{ secrets.CHECKOUT_TOKEN || github.token }}
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: '${{ inputs.python-version }}'
 

--- a/.github/workflows/twincat-style.yml
+++ b/.github/workflows/twincat-style.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash --login -o pipefail {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0
         submodules: 'recursive'

--- a/.github/workflows/twincat-summary.yml
+++ b/.github/workflows/twincat-summary.yml
@@ -34,13 +34,13 @@ jobs:
         shell: bash --login -o pipefail {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0
         submodules: 'recursive'
         token: ${{ secrets.CHECKOUT_TOKEN || github.token }}
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: '${{ inputs.python-version }}'
 

--- a/.github/workflows/twincat-syntax.yml
+++ b/.github/workflows/twincat-syntax.yml
@@ -39,13 +39,13 @@ jobs:
         shell: bash --login -o pipefail {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0
         submodules: 'recursive'
         token: ${{ secrets.CHECKOUT_TOKEN || github.token }}
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: '${{ inputs.python-version }}'
 

--- a/example_python_gha.yml
+++ b/example_python_gha.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   standard:
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-standard.yml@master
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-standard.yml@8cabad83e655bdc8ad62ead20e1539617b1bf35f
     with:
       # The workflow needs to know the package name.  This can be determined
       # automatically if the repository name is the same as the import name.

--- a/example_twincat_gha.yml
+++ b/example_twincat_gha.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   standard:
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/twincat-standard.yml@master
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/twincat-standard.yml@8cabad83e655bdc8ad62ead20e1539617b1bf35f
     with:
       # The workflow can be configured to look at a specific project directory, if
       # desirable.  This defaults to the root of the repository (".").


### PR DESCRIPTION
The bot made a bunch of version update PRs- maybe if I merge this, it will close those and replace them with SHA updates?

We are required to switch to SHA pinning soon by enterprise policy.