### PR TITLE
CI: temporarily disable problematic builds in standard workflows

### DIFF
--- a/.github/workflows/python-standard.yml
+++ b/.github/workflows/python-standard.yml
@@ -111,23 +111,23 @@ jobs:
       system-packages: ${{ inputs.pip-system-packages }}
       testing-extras: ${{ inputs.testing-extras }} ${{ inputs.pip-testing-extras }}
 
-  pip-docs:
-    name: "Documentation"
-    uses: ./.github/workflows/python-docs.yml
-    secrets: inherit
-    with:
-      package-name: ${{ inputs.package-name }}
-      python-version: ${{ inputs.python-version-docs }}
-      deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
-      docs-extras: ${{ inputs.docs-build-extras }}
-      system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}
-
-  coverage:
-    name: "Coverage"
-    uses: ./.github/workflows/python-coverage-test.yml
-    secrets: inherit
-    with:
-      package-name: ${{ inputs.package-name }}
-      python-version: ${{ inputs.python-version-docs }}
-      system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}
-      testing-extras: ${{ inputs.testing-extras }} ${{ inputs.pip-testing-extras }}
+#  pip-docs:
+#    name: "Documentation"
+#    uses: ./.github/workflows/python-docs.yml
+#    secrets: inherit
+#    with:
+#      package-name: ${{ inputs.package-name }}
+#      python-version: ${{ inputs.python-version-docs }}
+#      deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
+#      docs-extras: ${{ inputs.docs-build-extras }}
+#      system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}
+#
+#  coverage:
+#    name: "Coverage"
+#    uses: ./.github/workflows/python-coverage-test.yml
+#    secrets: inherit
+#    with:
+#      package-name: ${{ inputs.package-name }}
+#      python-version: ${{ inputs.python-version-docs }}
+#      system-packages: ${{ inputs.pip-system-packages }} ${{ inputs.docs-system-packages }}
+#      testing-extras: ${{ inputs.testing-extras }} ${{ inputs.pip-testing-extras }}

--- a/.github/workflows/twincat-standard.yml
+++ b/.github/workflows/twincat-standard.yml
@@ -49,13 +49,13 @@ jobs:
       project-root: ${{ inputs.project-root }}
       style-exclude: ${{ inputs.style-exclude }}
 
-  docs:
-    name: "Documentation"
-    secrets: inherit
-    uses: ./.github/workflows/python-docs.yml
-    with:
-      deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
-      package-name: ""
-      install-package: false
-      docs-template-repo: "pcdshub/twincat-docs-template"
-      docs-template-ref: "master"
+#  docs:
+#    name: "Documentation"
+#    secrets: inherit
+#    uses: ./.github/workflows/python-docs.yml
+#    with:
+#      deploy: ${{ github.repository_owner == inputs.docs-organization && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
+#      package-name: ""
+#      install-package: false
+#      docs-template-repo: "pcdshub/twincat-docs-template"
+#      docs-template-ref: "master"


### PR DESCRIPTION
All docs builds fail due to to needing write permissions
The coverage build fails in various repos and the output isn't really used

There will be a follow-up at some point to either re-enable the docs build or to document the right way to set up a separate docs job with increased permissions and to delete the commented out lines

There will be a follow-up at some point to either restore the coverage build in an always-working form or to delete the commented out lines

I will test this in `pcdswidgets` prior to merge