### PR TITLE
ENH: pixi/uv workflows

### DIFF
--- a/.github/workflows/docs-upload.yml
+++ b/.github/workflows/docs-upload.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   github-pages:
-    name: Github Pages Upload
     runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/docs-upload.yml
+++ b/.github/workflows/docs-upload.yml
@@ -1,0 +1,25 @@
+name: docs upload
+
+# Uploads a previously created docs html to the github pages site
+# Avoids pushing to a local branch to avoid cloning inefficiencies
+
+permissions:
+  pages: write
+  id-token: write
+
+on:
+  workflow_call:
+    inputs: {}
+    outputs: {}
+
+jobs:
+  github-pages:
+    name: Github Pages Upload
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+
+    steps:
+    - name: Deploy page
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/python-pixi-docs-build.yml
+++ b/.github/workflows/python-pixi-docs-build.yml
@@ -37,7 +37,7 @@ jobs:
         pixi-version: "v0.69.0"
 
     - name: Make docs
-      run: cd docs && pixi run --as-is make
+      run: cd docs && pixi run --as-is make html
 
     - name: Upload docs artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/python-pixi-docs-build.yml
+++ b/.github/workflows/python-pixi-docs-build.yml
@@ -13,6 +13,7 @@ on:
     inputs: {}
     outputs: {}
 
+# Ensure that docs builds that invoke qt don't crash
 env:
   MPLBACKEND: "agg"
   QT_QPA_PLATFORM: "offscreen"

--- a/.github/workflows/python-pixi-docs-build.yml
+++ b/.github/workflows/python-pixi-docs-build.yml
@@ -20,7 +20,6 @@ env:
 
 jobs:
   pixi-docs:
-    name: Pixi Docs Build
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/python-pixi-docs-build.yml
+++ b/.github/workflows/python-pixi-docs-build.yml
@@ -1,7 +1,9 @@
 name: pixi docs build
 
 # Use the Makefile inside the docs folder to build the docs.
-# Uses pixi to install the "docs" environment to ensure we have the necessary dependencies.
+# Assumes that the pixi default environment has the docs dependencies in it.
+# Assumes that the docs folder has a Makefile.
+# Assumes that the docs outputs are in docs/build/html
 
 permissions:
   contents: read
@@ -33,10 +35,9 @@ jobs:
       with:
         # Lock version to what we use in prod
         pixi-version: "v0.69.0"
-        environments: docs
 
     - name: Make docs
-      run: cd docs && pixi run --environment docs --as-is make
+      run: cd docs && pixi run --as-is make
 
     - name: Upload docs artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/python-pixi-docs-build.yml
+++ b/.github/workflows/python-pixi-docs-build.yml
@@ -1,0 +1,45 @@
+name: pixi docs build
+
+# Use the Makefile inside the docs folder to build the docs.
+# Uses pixi to install the "docs" environment to ensure we have the necessary dependencies.
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs: {}
+    outputs: {}
+
+jobs:
+  pixi-docs:
+    name: Pixi Docs Build
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        fetch-depth: 0
+        submodules: recursive
+        token: ${{ secrets.CHECKOUT_TOKEN || github.token }}
+
+    - name: Setup pixi environment
+      uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347
+      with:
+        # Lock version to what we use in prod
+        pixi-version: "v0.69.0"
+        environments: docs
+
+    - name: Make docs
+      run: cd docs && pixi run --environment docs --as-is make
+
+    - name: Upload docs artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: docs
+        path: docs/build/html

--- a/.github/workflows/python-pixi-docs-build.yml
+++ b/.github/workflows/python-pixi-docs-build.yml
@@ -13,6 +13,10 @@ on:
     inputs: {}
     outputs: {}
 
+env:
+  MPLBACKEND: "agg"
+  QT_QPA_PLATFORM: "offscreen"
+
 jobs:
   pixi-docs:
     name: Pixi Docs Build

--- a/.github/workflows/python-pixi-docs-build.yml
+++ b/.github/workflows/python-pixi-docs-build.yml
@@ -44,7 +44,6 @@ jobs:
       run: cd docs && pixi run --as-is make html
 
     - name: Upload docs artifacts
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
       with:
-        name: docs
         path: docs/build/html

--- a/.github/workflows/python-pixi-test.yml
+++ b/.github/workflows/python-pixi-test.yml
@@ -1,0 +1,53 @@
+name: pixi tests
+
+# Do "pixi run test", reporting the result.
+# This workflow expects the repo to have a pixi task named "test" configured.
+# Logfile artifacts will be uploaded so that they could be inspected offline.
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs: {}
+    outputs: {}
+
+env:
+  MPLBACKEND: "agg"
+  QT_QPA_PLATFORM: "offscreen"
+
+jobs:
+  pixi-tests:
+    name: Pixi Tests
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        fetch-depth: 0
+        submodules: recursive
+        token: ${{ secrets.CHECKOUT_TOKEN || github.token }}
+
+    - name: Setup pixi environment
+      uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347
+      with:
+        # Lock version to what we use in prod
+        pixi-version: "v0.69.0"
+
+    - name: Prepare for log files
+      run: mkdir ~/logs
+
+    - name: Run tests
+      run: pixi run test 2>&1 | tee ~/logs/pytest_log.txt
+
+    - name: Upload log file artifacts
+      if: ${{ always() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: pixi testing log
+        path: ~/logs

--- a/.github/workflows/python-pixi-test.yml
+++ b/.github/workflows/python-pixi-test.yml
@@ -1,8 +1,8 @@
 name: pixi tests
 
-# Do "pixi run test", reporting the result.
-# This workflow expects the repo to have a pixi task named "test" configured.
-# Logfile artifacts will be uploaded so that they could be inspected offline.
+# Use "pixi run test" to run the unit tests.
+# Assumes that the pixi default environment has the test dependencies in it.
+# Assumes that the pixi "test" task is configuerd to run reasonable tests.
 
 permissions:
   contents: read
@@ -12,6 +12,7 @@ on:
     inputs: {}
     outputs: {}
 
+# Ensure that unit tests that invoke qt don't crash
 env:
   MPLBACKEND: "agg"
   QT_QPA_PLATFORM: "offscreen"

--- a/.github/workflows/python-pixi-test.yml
+++ b/.github/workflows/python-pixi-test.yml
@@ -39,15 +39,5 @@ jobs:
         # Lock version to what we use in prod
         pixi-version: "v0.69.0"
 
-    - name: Prepare for log files
-      run: mkdir ~/logs
-
     - name: Run tests
-      run: pixi run test 2>&1 | tee ~/logs/pytest_log.txt
-
-    - name: Upload log file artifacts
-      if: ${{ always() }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-      with:
-        name: pixi testing log
-        path: ~/logs
+      run: pixi run --as-is test

--- a/.github/workflows/python-pixi-test.yml
+++ b/.github/workflows/python-pixi-test.yml
@@ -19,7 +19,6 @@ env:
 
 jobs:
   pixi-tests:
-    name: Pixi Tests
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/python-uv-build.yml
+++ b/.github/workflows/python-uv-build.yml
@@ -11,7 +11,7 @@ on:
   workflow_call:
     inputs:
       package-name:
-        description: "The Python-importable package name to be tested"
+        description: "The Python-importable package name to be built"
         required: true
         type: string
     outputs: {}

--- a/.github/workflows/python-uv-build.yml
+++ b/.github/workflows/python-uv-build.yml
@@ -43,10 +43,10 @@ jobs:
       run: uv build
 
     - name: Check the source distribution import
-      run: uv run --isolated --no-project --with "$(realpath ./dist/*.gz)" --directory /tmp -- python -c "import ${{ inputs.package-name }}; print(${{ inputs.package-name }}.__file)"
+      run: uv run --isolated --no-project --with "$(realpath ./dist/*.gz)" --directory /tmp -- python -c "import ${{ inputs.package-name }}; print(${{ inputs.package-name }}.__file__)"
 
     - name: Check the wheel distribution import
-      run: uv run --isolated --no-project --with "$(realpath ./dist/*.whl)" --directory /tmp -- python -c "import ${{ inputs.package-name }}; print(${{ inputs.package-name }}.__file)"
+      run: uv run --isolated --no-project --with "$(realpath ./dist/*.whl)" --directory /tmp -- python -c "import ${{ inputs.package-name }}; print(${{ inputs.package-name }}.__file__)"
 
     - name: Upload distributions as an artifact
       if: ${{ always() }}

--- a/.github/workflows/python-uv-build.yml
+++ b/.github/workflows/python-uv-build.yml
@@ -17,7 +17,6 @@ on:
 
 jobs:
   build-dist:
-    name: Build Distribution
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/python-uv-build.yml
+++ b/.github/workflows/python-uv-build.yml
@@ -1,8 +1,7 @@
 name: uv build
 
 # Use "uv build" to build the sdist and wheels, then ensure that these can be imported when installed.
-# This workflow expects the repo to have a buildable python project present.
-
+# Assumes that the repo has a buildable python project present.
 
 permissions:
   contents: read

--- a/.github/workflows/python-uv-build.yml
+++ b/.github/workflows/python-uv-build.yml
@@ -1,0 +1,56 @@
+name: uv build
+
+# Use "uv build" to build the sdist and wheels, then ensure that these can be imported when installed.
+# This workflow expects the repo to have a buildable python project present.
+
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        description: "The Python-importable package name to be tested"
+        required: true
+        type: string
+    outputs: {}
+
+jobs:
+  build-dist:
+    name: Build Distribution
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        fetch-depth: 0
+        submodules: recursive
+        token: ${{ secrets.CHECKOUT_TOKEN || github.token }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+      with:
+        # Lock version to what we use in prod
+        version: "0.11.18"
+
+    - name: Build package
+      run: uv build
+
+    - name: Check the source distribution import
+      run: uv run --isolated --no-project --with "$(realpath ./dist/*.gz)" --directory /tmp -- python -c "import ${{ inputs.package-name }}; print(${{ inputs.package-name }}.__file)"
+
+    - name: Check the wheel distribution import
+      run: uv run --isolated --no-project --with "$(realpath ./dist/*.whl)" --directory /tmp -- python -c "import ${{ inputs.package-name }}; print(${{ inputs.package-name }}.__file)"
+
+    - name: Upload distributions as an artifact
+      if: ${{ always() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: dist
+        path: dist

--- a/.github/workflows/python-uv-publish.yml
+++ b/.github/workflows/python-uv-publish.yml
@@ -1,8 +1,7 @@
 name: uv publish
 
 # Publish the build outputs from the python-uv-build workflow.
-# This workflow requires the repository to be set up as a trusted publisher with pypi,
-# using a "pypi" environment.
+# Assumes that the repo is a trusted publisher on pypi, using a "pypi" environment.
 
 permissions:
   id-token: write

--- a/.github/workflows/python-uv-publish.yml
+++ b/.github/workflows/python-uv-publish.yml
@@ -1,0 +1,40 @@
+name: uv publish
+
+# Publish the build outputs from the python-uv-build workflow.
+# This workflow requires the repository to be set up as a trusted publisher with pypi,
+# using a "pypi" environment.
+
+permissions:
+  id-token: write
+
+on:
+  workflow_call:
+    inputs: {}
+    outputs: {}
+
+jobs:
+  publish-dist:
+    name: Publish Distribution
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+      with:
+        # Lock version to what we use in prod
+        version: "0.11.18"
+
+    - name: Download distributions artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: dist
+        path: dist/
+
+    - name: Publish
+      run: uv publish

--- a/.github/workflows/python-uv-publish.yml
+++ b/.github/workflows/python-uv-publish.yml
@@ -13,7 +13,6 @@ on:
 
 jobs:
   publish-dist:
-    name: Publish Distribution
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/python-uv-publish.yml
+++ b/.github/workflows/python-uv-publish.yml
@@ -31,7 +31,7 @@ jobs:
         version: "0.11.18"
 
     - name: Download distributions artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: dist
         path: dist/

--- a/example_python_gha.yml
+++ b/example_python_gha.yml
@@ -1,5 +1,16 @@
 name: ECS Pixi Testing
 
+# The standard build, assuming the python repo uses pixi.
+# This full template will:
+# - Run pre-commit
+# - Run unit tests with pixi
+# - Build the package with uv for distributions
+# - Upload the distribution to pypi on tag
+# - Build the docs with pixi for github pages
+# - Upload the docs to github-pages on tag
+#
+# To skip a section, simply remove it from the workflow.
+
 on:
   push:
     branches:
@@ -10,35 +21,41 @@ on:
       - created
 
 jobs:
+  # Checks the pre-commit rules. Configure this by editing .pre-commit-config.yaml in your repo.
   pre-commit:
     permissions:
       contents: read
     uses: pcdshub/pcds-ci-helpers/.github/workflows/pre-commit.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
 
+  # Runs the unit tests. Configure this by customizing what happens when we call "pixi run test", e.g. the "test" task.
   unit-tests:
     permissions:
       contents: read
     uses: pcdshub/pcds-ci-helpers/.github/workflows/python-pixi-test.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
 
-  packaging-tests:
+  # Creates the files that we would upload to pypi and makes sure they work. "package-name" should be correct to validate the builds.
+  pypi-build:
     permissions:
       contents: read
     uses: pcdshub/pcds-ci-helpers/.github/workflows/python-uv-build.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
     with:
       package-name: "import_name_goes_here"
 
+  # On tag, uploads the files from packaging-tests to pypi. Requires trusted publishing to be set up.
   pypi-upload:
     permissions:
       id-token: write
-    needs: packaging-tests
+    needs: pypi-build
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     uses: pcdshub/pcds-ci-helpers/.github/workflows/python-uv-publish.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
 
+  # Builds the documentation html files that should be uploaded to github pages. Configure by editing the result of "make html" in the docs folder.
   docs-build:
     permissions:
       contents: read
     uses: pcdshub/pcds-ci-helpers/.github/workflows/python-pixi-docs-build.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
 
+  # Uploads the documentation html files from docs-build. Requires the "github-pages" environment to be set up.
   docs-upload:
     permissions:
       pages: write

--- a/example_python_gha.yml
+++ b/example_python_gha.yml
@@ -10,6 +10,8 @@ name: ECS Pixi Testing
 # - Upload the docs to github-pages on tag
 #
 # To skip a section, simply remove it from the workflow.
+# When you apply this to a repo for the first time,
+# replace the "sha" in each "uses" line with the actual full SHA of the latest tag. 
 
 on:
   push:
@@ -25,19 +27,19 @@ jobs:
   pre-commit:
     permissions:
       contents: read
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/pre-commit.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/pre-commit.yml@sha
 
   # Runs the unit tests. Configure this by customizing what happens when we call "pixi run test", e.g. the "test" task.
   unit-tests:
     permissions:
       contents: read
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-pixi-test.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-pixi-test.yml@sha
 
   # Creates the files that we would upload to pypi and makes sure they work. "package-name" should be correct to validate the builds.
   pypi-build:
     permissions:
       contents: read
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-uv-build.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-uv-build.yml@sha
     with:
       package-name: "import_name_goes_here"
 
@@ -47,13 +49,13 @@ jobs:
       id-token: write
     needs: pypi-build
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-uv-publish.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-uv-publish.yml@sha
 
   # Builds the documentation html files that should be uploaded to github pages. Configure by editing the result of "make html" in the docs folder.
   docs-build:
     permissions:
       contents: read
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-pixi-docs-build.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-pixi-docs-build.yml@sha
 
   # Uploads the documentation html files from docs-build. Requires the "github-pages" environment to be set up.
   docs-upload:
@@ -62,4 +64,4 @@ jobs:
       id-token: write
     needs: docs-build
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/docs-upload.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/docs-upload.yml@sha

--- a/example_python_gha.yml
+++ b/example_python_gha.yml
@@ -1,24 +1,48 @@
-name: PCDS Standard Testing
+name: ECS Pixi Testing
 
 on:
   push:
+    branches:
+      - "master"
   pull_request:
   release:
     types:
-      - published
+      - created
 
 jobs:
-  standard:
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-standard.yml@8cabad83e655bdc8ad62ead20e1539617b1bf35f
+  pre-commit:
+    permissions:
+      contents: read
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/pre-commit.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
+
+  unit-tests:
+    permissions:
+      contents: read
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-pixi-test.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
+
+  packaging-tests:
+    permissions:
+      contents: read
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-uv-build.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
     with:
-      # The workflow needs to know the package name.  This can be determined
-      # automatically if the repository name is the same as the import name.
       package-name: "import_name_goes_here"
-      # Extras that will be installed for both conda/pip:
-      testing-extras: ""
-      # Extras to be installed only for conda-based testing:
-      conda-testing-extras: ""
-      # Extras to be installed only for pip-based testing:
-      pip-testing-extras: ""
-      # Use setuptools-scm in the conda-build workflow
-      use-setuptools-scm: false
+
+  pypi-upload:
+    permissions:
+      id-token: write
+    needs: packaging-tests
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-uv-publish.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
+
+  docs-build:
+    permissions:
+      contents: read
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-pixi-docs-build.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610
+
+  docs-upload:
+    permissions:
+      pages: write
+      id-token: write
+    needs: docs-build
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/docs-upload.yml@f74a9345ef8ff8119f76ef087c9222f6000f2610

--- a/example_python_gha.yml
+++ b/example_python_gha.yml
@@ -11,7 +11,7 @@ name: ECS Pixi Testing
 #
 # To skip a section, simply remove it from the workflow.
 # When you apply this to a repo for the first time,
-# replace the "sha" in each "uses" line with the actual full SHA of the latest tag. 
+# replace the "sha" in each "uses" line with the actual full SHA of the latest tag.
 
 on:
   push:

--- a/example_python_gha.yml
+++ b/example_python_gha.yml
@@ -43,7 +43,7 @@ jobs:
     with:
       package-name: "import_name_goes_here"
 
-  # On tag, uploads the files from packaging-tests to pypi. Requires trusted publishing to be set up.
+  # On tag, uploads the files from pypi-build to pypi. Requires trusted publishing to be set up.
   pypi-upload:
     permissions:
       id-token: write


### PR DESCRIPTION
These are the first versions of the pixi workflows that I'd like to deploy (starting with pcdswidgets and the ctrlenv repos). I'm intending to proliferate these to the python repos as we transition their pip/conda environments to pixi.

The first versions are unlikely to be feature-complete. This is somewhat intentional- I'd like to keep these workflows as simple as possible. If you compare them to the conda and pip workflows you'll notice that a lot of features were cut. I think it's better to cut these now and add them back as needed rather than assume the full technical debt up front.

The previous workflows were strung together by using this `python-standard.yml` workflow, simplifying the deployment and job linking logic, but not allowing us to assign different permissions to each job, making it difficult to comply with best cybersecurity principles of minimum permissions. There is no corresponding file in this update, but the example workflow has been updated to the one I'm trying in https://github.com/pcdshub/pcdswidgets/pull/138. You'll notice that it is more complex and it encodes some of the sequencing logic, and it has fewer options in general, but I think this is a good tradeoff. We can individually enable/disable jobs in each repo via choosing which workflows to include rather than by navigating the options maze and we can make sure the jobs that run on each PR or push only have "read" access, reserving increased permissions to the "tag" builds.

I currently have:
- `docs-upload.yml`: generic docs uploader, currently requires the python repo pixi docs build but could be used for the twincat repos later too. 
- `python-pixi-docs-build.yml`: builds the docs using the repo's pixi environment
- `python-pixi-test.yml`: more or less just does `pixi run test`
- `python-uv-build.yml`: builds and does simple checks on the packaged distributions
- `python-uv-upload.yml`: uses the builds to upload to pypi

I'm leaning heavily on the following webpages as I work through this:
- https://pixi.prefix.dev/latest/integration/ci/github_actions/
- https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi

These require the "pypi" and "gh-pages" environments to be set up in the repo to handle the uploads. I'm configuring these appropriately in pcdswidgets to start but will likely need to iterate on them as we go.

Note that the uploads have not been tested- I think I will iterate on these at the next `pcdswidgets` tag.